### PR TITLE
feat: Upload to Cogfy reads from PostgreSQL instead of HuggingFace

### DIFF
--- a/.github/workflows/pipeline-steps.yaml
+++ b/.github/workflows/pipeline-steps.yaml
@@ -126,13 +126,14 @@ jobs:
       - name: Get secrets from Secret Manager
         id: secrets
         run: |
-          echo "HF_TOKEN=$(gcloud secrets versions access latest --secret=hf-token)" >> $GITHUB_OUTPUT
+          echo "DATABASE_URL=$(gcloud secrets versions access latest --secret=govbrnews-postgres-connection-string)" >> $GITHUB_OUTPUT
           echo "COGFY_API_KEY=$(gcloud secrets versions access latest --secret=cogfy-api-key)" >> $GITHUB_OUTPUT
 
       - name: Upload news to Cogfy
         run: |
           docker run --rm \
-            -e HF_TOKEN="${{ steps.secrets.outputs.HF_TOKEN }}" \
+            -e STORAGE_READ_FROM=postgres \
+            -e DATABASE_URL="${{ steps.secrets.outputs.DATABASE_URL }}" \
             -e COGFY_API_KEY="${{ steps.secrets.outputs.COGFY_API_KEY }}" \
             ghcr.io/destaquesgovbr/data-platform:latest \
             data-platform upload-cogfy --start-date "${{ inputs.start_date }}" --end-date "${{ inputs.end_date }}"


### PR DESCRIPTION
## Summary
- Modified `UploadToCogfyManager` to use `StorageAdapter` for flexible data source
- Added `COGFY_FIELD_TYPES` static mapping for PostgreSQL reads
- Updated `_load_and_prepare_dataset` to support both PostgreSQL and HuggingFace
- Updated `_setup_collection_fields` to handle Cogfy types directly
- Updated `pipeline-steps.yaml` to use `STORAGE_READ_FROM=postgres`

## Motivation
This change reduces dependency on HuggingFace for the upload step, reading directly from PostgreSQL which is now the source of truth after the dual-write implementation.

## Test plan
- [ ] Run pipeline with `cogfy_wait_minutes=1` to test quickly
- [ ] Verify Upload to Cogfy step reads from PostgreSQL
- [ ] Verify Enrich step still works with dual-write

🤖 Generated with [Claude Code](https://claude.com/claude-code)