### PR TITLE
feat: obtain Composer DAGs bucket dynamically

### DIFF
--- a/.github/workflows/composer-deploy-dags.yaml
+++ b/.github/workflows/composer-deploy-dags.yaml
@@ -21,7 +21,6 @@ env:
   PROJECT_ID: inspire-7-finep
   COMPOSER_ENVIRONMENT: destaquesgovbr-composer
   COMPOSER_REGION: us-central1
-  DAGS_BUCKET: gs://us-central1-destaquesgovbr--30208ee3-bucket/dags
   DAGS_LOCAL_PATH: src/data_platform/dags
 
 jobs:
@@ -99,6 +98,15 @@ jobs:
         with:
           project_id: ${{ env.PROJECT_ID }}
 
+      - name: Get Composer DAGs bucket
+        id: composer
+        run: |
+          DAGS_BUCKET=$(gcloud composer environments describe ${{ env.COMPOSER_ENVIRONMENT }} \
+            --location=${{ env.COMPOSER_REGION }} \
+            --format="value(config.dagGcsPrefix)")
+          echo "dags_bucket=$DAGS_BUCKET" >> $GITHUB_OUTPUT
+          echo "DAGs bucket: $DAGS_BUCKET"
+
       - name: List DAGs to deploy
         run: |
           echo "DAGs to be deployed:"
@@ -119,16 +127,16 @@ jobs:
 
       - name: Deploy DAGs to GCS
         run: |
-          echo "Syncing DAGs to ${{ env.DAGS_BUCKET }}..."
+          echo "Syncing DAGs to ${{ steps.composer.outputs.dags_bucket }}..."
           gsutil -m rsync -r -d \
             -x "requirements\.txt$" \
-            ${{ env.DAGS_LOCAL_PATH }}/ ${{ env.DAGS_BUCKET }}/
+            ${{ env.DAGS_LOCAL_PATH }}/ ${{ steps.composer.outputs.dags_bucket }}/
           echo "DAGs deployed successfully!"
 
       - name: Verify deployment
         run: |
           echo "Verifying DAGs in bucket..."
-          gsutil ls -l ${{ env.DAGS_BUCKET }}/
+          gsutil ls -l ${{ steps.composer.outputs.dags_bucket }}/
 
       - name: Wait for Airflow to parse DAGs
         run: |


### PR DESCRIPTION
## Summary

- Remove hardcoded `DAGS_BUCKET` environment variable from the deploy workflow
- Add new step to query the DAGs bucket dynamically using `gcloud composer environments describe`
- Update all bucket references to use the step output

## Why

When Cloud Composer is recreated (for any reason), GCP generates a new bucket with a different hash (e.g., `gs://us-central1-destaquesgovbr--30208ee3-bucket` → `gs://us-central1-destaquesgovbr--a02910d4-bucket`). This previously broke the deploy workflow until the hardcoded value was manually updated.

## Benefits

1. **Resilience** - Deploy works even after Composer recreation
2. **Infrastructure immutability** - Infrastructure can be recreated without code changes
3. **Multi-environment ready** - Facilitates deploy to dev/staging/prod
4. **Single source of truth** - Configuration comes directly from GCP

## Test plan

- [ ] Run the workflow manually (`workflow_dispatch`)
- [ ] Verify in logs that the bucket was discovered correctly
- [ ] Confirm DAGs were deployed to the correct bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)