### PR TITLE
fix(typesense): add video_url to document indexing

### DIFF
--- a/src/data_platform/typesense/indexer.py
+++ b/src/data_platform/typesense/indexer.py
@@ -125,6 +125,7 @@ def prepare_document(row: pd.Series) -> dict[str, Any]:
         "title",
         "url",
         "image",
+        "video_url",
         "category",
         "content",
         "summary",


### PR DESCRIPTION
## Summary

- Fixed bug where `video_url` field was not being included in Typesense documents
- The field was correctly defined in schema and SQL query, but missing from `prepare_document()` in `indexer.py`

## Root Cause

The `video_url` field was:
- ✅ Defined in Typesense schema (`collection.py:29`)
- ✅ Selected in SQL query (`postgres_manager.py:515`)
- ❌ Missing from `optional_string_fields` list in `prepare_document()`

## Verification (Production)

| System | Status |
|--------|--------|
| PostgreSQL PRD | 1,698 records with `video_url` populated |
| Typesense PRD | Field in schema, but **empty** in all documents |

## Test Plan

- [x] Manual test of `prepare_document()` with video_url value
- [x] Manual test of `prepare_document()` without video_url (None)
- [ ] Run full sync after merge to populate existing documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)