### PR TITLE
fix: disable HuggingFace writes to isolate dataset error

### DIFF
--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -88,7 +88,7 @@ jobs:
             AGENCIES_ARG="--agencies ${{ inputs.agencies }}"
           fi
           docker run --rm \
-            -e STORAGE_BACKEND=dual_write \
+            -e STORAGE_BACKEND=postgres \
             -e DATABASE_URL="${{ steps.secrets.outputs.DATABASE_URL }}" \
             -e HF_TOKEN="${{ steps.secrets.outputs.HF_TOKEN }}" \
             ghcr.io/destaquesgovbr/data-platform:latest \
@@ -127,7 +127,7 @@ jobs:
       - name: Run EBC news scraper
         run: |
           docker run --rm \
-            -e STORAGE_BACKEND=dual_write \
+            -e STORAGE_BACKEND=postgres \
             -e DATABASE_URL="${{ steps.secrets.outputs.DATABASE_URL }}" \
             -e HF_TOKEN="${{ steps.secrets.outputs.HF_TOKEN }}" \
             ghcr.io/destaquesgovbr/data-platform:latest \
@@ -254,7 +254,7 @@ jobs:
         env:
           COGFY_API_KEY: ${{ steps.secrets.outputs.COGFY_API_KEY }}
           HF_TOKEN: ${{ steps.secrets.outputs.HF_TOKEN }}
-          STORAGE_BACKEND: dual_write
+          STORAGE_BACKEND: postgres
           STORAGE_READ_FROM: postgres
           DATABASE_URL: ${{ steps.secrets.outputs.DATABASE_URL }}
         run: |


### PR DESCRIPTION
## Summary

- Temporarily switches `STORAGE_BACKEND` from `dual_write` to `postgres` in the main workflow
- Bypasses the `NonMatchingSplitsSizesError` that was failing the enrichment step
- Data continues to be written to PostgreSQL (primary source of truth)

## Changes

| Job | Before | After |
|-----|--------|-------|
| scraper | `dual_write` | `postgres` |
| ebc-scraper | `dual_write` | `postgres` |
| enrich-themes | `dual_write` | `postgres` |

## Context

The pipeline was failing with:
```
NonMatchingSplitsSizesError: 
  expected: num_examples=309346
  recorded: num_examples=309629
```

This is caused by a schema mismatch in the HuggingFace dataset that needs to be investigated separately.

## Test plan

- [ ] Run workflow from this branch with test parameters
- [ ] Verify all jobs pass successfully
- [ ] Confirm data is written to PostgreSQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)