### PR TITLE
fix(composer): corrigir formato requirements.txt e deploy source via plugins/

### DIFF
--- a/.github/workflows/composer-deploy-dags.yaml
+++ b/.github/workflows/composer-deploy-dags.yaml
@@ -9,6 +9,9 @@ on:
       - main
     paths:
       - 'src/data_platform/dags/**'
+      - 'src/data_platform/scrapers/**'
+      - 'src/data_platform/managers/**'
+      - 'src/data_platform/models/**'
   workflow_dispatch:
     inputs:
       test_connections:
@@ -134,6 +137,16 @@ jobs:
           else
             echo "No requirements.txt found, skipping dependency update"
           fi
+
+      - name: Deploy data_platform source to plugins/
+        run: |
+          # Composer plugins/ dir is on PYTHONPATH, making data_platform importable
+          PLUGINS_BUCKET=$(echo "${{ steps.composer.outputs.dags_bucket }}" | sed 's|/dags$|/plugins|')
+          echo "Syncing data_platform source to $PLUGINS_BUCKET/data_platform/..."
+          gsutil -m rsync -r \
+            src/data_platform/ $PLUGINS_BUCKET/data_platform/ \
+            -x "dags/.*|__pycache__/.*|\.pyc$"
+          echo "Source code deployed to plugins!"
 
       - name: Deploy DAGs to GCS
         run: |

--- a/src/data_platform/dags/requirements.txt
+++ b/src/data_platform/dags/requirements.txt
@@ -7,5 +7,12 @@ huggingface-hub==0.27.0
 pyarrow>=14.0.0
 requests>=2.31.0
 
-# Scraper dependencies (data-platform package installed via git)
-data-platform @ git+https://github.com/destaquesgovbr/data-platform.git
+# Scraper dependencies (código fonte é deployado via plugins/ no workflow)
+# Abaixo estão apenas as dependências pip que os scrapers precisam
+beautifulsoup4>=4.12.3
+retry>=0.9.2
+markdownify>=0.14.1
+markdown>=3.7
+pyyaml>=6.0.2
+pydantic>=2.5.3
+pydantic-settings>=2.1.0


### PR DESCRIPTION
## Summary

- Corrige falha silenciosa na instalação de dependências do scraper no Composer
- `data-platform @ git+https://...` não é suportado pelo `--update-pypi-packages-from-file`
- Substitui por dependências individuais (beautifulsoup4, retry, markdownify, etc.)
- Adiciona step no workflow para deploy do código-fonte via `plugins/` (PYTHONPATH do Composer)

## Problema

O step "Deploy requirements.txt" falhava com:
```
Error validating key data-platform @ git+https://github.com/destaquesgovbr/data-platform.git.
PyPI dependency name is not formatted properly.
```
Mas era mascarado pelo `|| echo "No package changes needed"`.

## Solução

1. **requirements.txt**: lista as dependências pip individualmente
2. **Workflow**: novo step `Deploy data_platform source to plugins/` faz rsync do source code para `gs://BUCKET/plugins/data_platform/`, que está no PYTHONPATH do Composer
3. **Trigger paths**: expandido para incluir `scrapers/`, `managers/`, `models/` (redeploy ao mudar source code)

## Test plan

- [ ] Merge e verificar workflow executa com sucesso
- [ ] Confirmar pacotes instalados: `gcloud composer environments describe ... --format="value(config.softwareConfig.pypiPackages)"`
- [ ] Verificar source code no plugins: `gsutil ls gs://BUCKET/plugins/data_platform/`
- [ ] Trigger manual de uma DAG de scraping no Airflow UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)