### PR TITLE
fix(workflow): corrigir ordem dos args do gsutil rsync

### DIFF
--- a/.github/workflows/composer-deploy-dags.yaml
+++ b/.github/workflows/composer-deploy-dags.yaml
@@ -144,8 +144,8 @@ jobs:
           PLUGINS_BUCKET=$(echo "${{ steps.composer.outputs.dags_bucket }}" | sed 's|/dags$|/plugins|')
           echo "Syncing data_platform source to $PLUGINS_BUCKET/data_platform/..."
           gsutil -m rsync -r \
-            src/data_platform/ $PLUGINS_BUCKET/data_platform/ \
-            -x "dags/.*|__pycache__/.*|\.pyc$"
+            -x "dags/.*|__pycache__/.*|\.pyc$" \
+            src/data_platform/ $PLUGINS_BUCKET/data_platform/
           echo "Source code deployed to plugins!"
 
       - name: Deploy DAGs to GCS


### PR DESCRIPTION
## Summary

- Corrige ordem dos argumentos do `gsutil rsync` no step de deploy de plugins
- O flag `-x` (exclude) precisa vir antes dos paths src/dst

## Problema

```
CommandException: The rsync command accepts at most 2 arguments.
```

O `-x "..."` estava após os paths, fazendo o gsutil interpretar como 3 argumentos.

## Test plan

- [ ] Workflow executa sem erro no step "Deploy data_platform source to plugins/"

🤖 Generated with [Claude Code](https://claude.com/claude-code)