### PR TITLE
fix(composer): adicionar loguru e scipy ao requirements.txt

### DIFF
--- a/src/data_platform/dags/requirements.txt
+++ b/src/data_platform/dags/requirements.txt
@@ -16,3 +16,5 @@ markdown>=3.7
 pyyaml>=6.0.2
 pydantic>=2.5.3
 pydantic-settings>=2.1.0
+loguru>=0.7.2
+scipy>=1.11.0


### PR DESCRIPTION
## Summary

- Adiciona `loguru>=0.7.2` e `scipy>=1.11.0` ao requirements.txt do Composer
- Corrige `ModuleNotFoundError: No module named 'loguru'` nas DAGs de scraping

## Problema

As DAGs `scrape_agencies` e `scrape_ebc` falhavam ao importar `StorageAdapter`:
```
from data_platform.managers import StorageAdapter
  → from data_platform.managers.postgres_manager import PostgresManager
    → from loguru import logger
ModuleNotFoundError: No module named 'loguru'
```

## Test plan

- [ ] Verificar pacotes instalados no Composer após deploy
- [ ] Trigger manual de DAG de scraping sem erro de import

🤖 Generated with [Claude Code](https://claude.com/claude-code)