### PR TITLE
Remove unused requirements.txt step from DAG deploy

### DIFF
--- a/.github/workflows/composer-deploy-dags.yaml
+++ b/.github/workflows/composer-deploy-dags.yaml
@@ -122,19 +122,6 @@ jobs:
           echo "DAGs to be deployed:"
           ls -la ${{ env.DAGS_LOCAL_PATH }}/
 
-      - name: Deploy requirements.txt (if exists)
-        run: |
-          if [ -f "${{ env.DAGS_LOCAL_PATH }}/requirements.txt" ]; then
-            echo "Found requirements.txt, updating Composer environment..."
-            gcloud composer environments update ${{ env.COMPOSER_ENVIRONMENT }} \
-              --location=${{ env.COMPOSER_REGION }} \
-              --update-pypi-packages-from-file=${{ env.DAGS_LOCAL_PATH }}/requirements.txt \
-              || echo "No package changes needed (packages already installed)"
-            echo "Requirements check completed!"
-          else
-            echo "No requirements.txt found, skipping dependency update"
-          fi
-
       - name: Clean stale plugins
         run: |
           # DAGs now call Cloud Run API via HTTP - no local source code needed in plugins/


### PR DESCRIPTION
## Summary

- Remove the `Deploy requirements.txt (if exists)` step from `composer-deploy-dags.yaml`
- Composer packages are managed exclusively via Terraform (`pypi_packages` in `composer.tf`)
- This step was never triggered (no `requirements.txt` exists) and added unnecessary complexity

See `docs/architecture/decentralized-dags.md` for the package management convention.