### PR TITLE
refactor: use reusable workflow for DAG deployment

### DIFF
--- a/.github/workflows/composer-deploy-dags.yaml
+++ b/.github/workflows/composer-deploy-dags.yaml
@@ -17,86 +17,33 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+  id-token: write
+
 env:
   PROJECT_ID: inspire-7-finep
   COMPOSER_ENVIRONMENT: destaquesgovbr-composer
   COMPOSER_REGION: us-central1
-  DAGS_LOCAL_PATH: src/data_platform/dags
 
 jobs:
-  validate-dags:
-    name: Validate DAGs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  deploy:
+    uses: destaquesgovbr/reusable-workflows/.github/workflows/composer-deploy-dags.yml@v1
+    with:
+      dags_local_path: src/data_platform/dags
+      dags_bucket_subdir: data-platform
+      check_imports: true
+      rsync_exclude: 'requirements\.txt$'
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install apache-airflow==3.0.1 apache-airflow-providers-postgres
-
-      - name: Validate DAG syntax
-        run: |
-          echo "Validating DAG files..."
-          for dag_file in ${{ env.DAGS_LOCAL_PATH }}/*.py; do
-            if [ -f "$dag_file" ]; then
-              echo "Checking: $dag_file"
-              python -m py_compile "$dag_file"
-              echo "  Syntax OK"
-            fi
-          done
-          echo "All DAG files validated successfully!"
-
-      - name: Check for import errors
-        run: |
-          echo "Checking for import errors..."
-          export AIRFLOW_HOME=$(mktemp -d)
-          airflow db migrate > /dev/null 2>&1 || true
-
-          for dag_file in ${{ env.DAGS_LOCAL_PATH }}/*.py; do
-            if [ -f "$dag_file" ]; then
-              echo "Testing imports: $dag_file"
-              python -c "
-          import sys
-          sys.path.insert(0, '.')
-          try:
-              exec(open('$dag_file').read())
-              print('  Imports OK')
-          except Exception as e:
-              print(f'  Warning: {e}')
-              # Don't fail on import errors that might be due to missing Airflow context
-          "
-            fi
-          done
-
-  deploy-dags:
-    name: Deploy DAGs to Composer
-    needs: validate-dags
+  cleanup:
+    name: Clean stale artifacts
+    needs: deploy
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
 
     steps:
-      - name: Log trigger source
-        run: |
-          echo "## Deploy Triggered" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "🖱️ **Triggered by**: Manual dispatch" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "📦 **Triggered by**: Push to main (DAG changes)" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -115,12 +62,6 @@ jobs:
             --location=${{ env.COMPOSER_REGION }} \
             --format="value(config.dagGcsPrefix)")
           echo "dags_bucket=$DAGS_BUCKET" >> $GITHUB_OUTPUT
-          echo "DAGs bucket: $DAGS_BUCKET"
-
-      - name: List DAGs to deploy
-        run: |
-          echo "DAGs to be deployed:"
-          ls -la ${{ env.DAGS_LOCAL_PATH }}/
 
       - name: Clean stale plugins
         run: |
@@ -144,27 +85,9 @@ jobs:
           gsutil rm -r "$BUCKET/config/" 2>/dev/null && echo "  Removed config/" || true
           echo "Legacy cleanup done"
 
-      - name: Deploy DAGs to GCS
-        run: |
-          echo "Syncing DAGs to ${{ steps.composer.outputs.dags_bucket }}/data-platform/..."
-          gsutil -m rsync -r -d \
-            -x "requirements\.txt$" \
-            ${{ env.DAGS_LOCAL_PATH }}/ ${{ steps.composer.outputs.dags_bucket }}/data-platform/
-          echo "DAGs deployed successfully!"
-
-      - name: Verify deployment
-        run: |
-          echo "Verifying DAGs in bucket..."
-          gsutil ls -l ${{ steps.composer.outputs.dags_bucket }}/data-platform/
-
-      - name: Wait for Airflow to parse DAGs
-        run: |
-          echo "Waiting 60 seconds for Airflow to parse new DAGs..."
-          sleep 60
-
   test-connections:
     name: Test Airflow Connections
-    needs: deploy-dags
+    needs: deploy
     if: github.event.inputs.test_connections == 'true'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Replace inline validate+deploy logic with call to `destaquesgovbr/reusable-workflows/.github/workflows/composer-deploy-dags.yml@v1`
- Keep `cleanup` and `test-connections` jobs local (data-platform specific)
- Add workflow-level `permissions` for reusable workflow inheritance

## Validated
- Reusable workflow tested successfully via scraper repo (run #22405293247)