### PR TITLE
cleanup: remover código morto e referências HF obsoletas

### DIFF
--- a/src/data_platform/managers/dataset_manager.py
+++ b/src/data_platform/managers/dataset_manager.py
@@ -57,8 +57,8 @@ class DatasetManager:
         # Sort the dataset before pushing
         dataset = self._sort_dataset(dataset)
 
-        # Push updated dataset (and CSVs) to the Hub
-        self._push_dataset_and_csvs(dataset)
+        # Push updated dataset to the Hub
+        self._push_datasets(dataset)
 
     def update(self, updated_df: pd.DataFrame):
         """
@@ -79,8 +79,8 @@ class DatasetManager:
         # Sort again after updates
         dataset = self._sort_dataset(dataset)
 
-        # Push updated dataset (and CSVs) to the Hub
-        self._push_dataset_and_csvs(dataset)
+        # Push updated dataset to the Hub
+        self._push_datasets(dataset)
 
     def get(
         self, min_date: str, max_date: str, agency: Optional[str] = None
@@ -263,7 +263,7 @@ class DatasetManager:
         )
         return Dataset.from_pandas(df, preserve_index=False)
 
-    def _push_dataset_and_csvs(self, dataset: Dataset):
+    def _push_datasets(self, dataset: Dataset):
         """
         Push the HF Dataset to the Hub and push a reduced version
         containing only 'published_at', 'agency', 'title', and 'url' columns.


### PR DESCRIPTION
## Summary

- Remove referências a "HuggingFace" em docstrings e logs do `enrichment_manager.py`, substituindo por terminologia genérica ("storage backend")
- Remove código morto de upload CSV em `dataset_manager.py`: imports não utilizados (`tempfile`, `requests`, `HfApi`, `retry`), atributo `self.api`, 6 métodos de upload CSV e chamadas comentadas (-107 linhas)

## Contexto

Parte do PR #72 original, rebaseado após a extração do scraper para o repositório standalone. As alterações do scraper foram migradas para [destaquesgovbr/scraper#8](https://github.com/destaquesgovbr/scraper/pull/8).

## Test plan

- [ ] Verificar que `enrichment_manager.py` funciona normalmente (apenas mudanças em texto)
- [ ] Verificar que `dataset_manager.py` ainda faz push correto para HuggingFace Hub (métodos removidos já não eram chamados)
- [ ] Rodar `pytest` para garantir que nenhum teste quebrou

🤖 Generated with [Claude Code](https://claude.com/claude-code)