### PR TITLE
fix: expose PostgresManager.engine as public property

### DIFF
--- a/src/data_platform/managers/postgres_manager.py
+++ b/src/data_platform/managers/postgres_manager.py
@@ -57,6 +57,11 @@ class PostgresManager:
         self._themes_by_id: dict[int, Theme] = {}
         self._cache_loaded = False
 
+    @property
+    def engine(self):
+        """Public access to SQLAlchemy engine for pandas read_sql operations."""
+        return self._engine
+
     def _get_connection_string(self) -> str:
         """
         Get database connection string from environment, Secret Manager, or use localhost.


### PR DESCRIPTION
Fixes typesense-sync-worker crash: `'PostgresManager' object has no attribute 'engine'`. The handler uses `pg.engine` but the attribute was private (`_engine`).