### PR TITLE
fix: corrige SQL BigQuery e adiciona deploy de DAGs

### DIFF
--- a/.github/workflows/composer-deploy-dags.yaml
+++ b/.github/workflows/composer-deploy-dags.yaml
@@ -1,0 +1,19 @@
+name: Deploy DAGs to Composer
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'src/data_platform/dags/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    uses: destaquesgovbr/reusable-workflows/.github/workflows/composer-deploy-dags.yml@v1
+    with:
+      dags_local_path: src/data_platform/dags
+      dags_bucket_subdir: data-platform

--- a/scripts/bigquery/create_pageviews.sql
+++ b/scripts/bigquery/create_pageviews.sql
@@ -5,8 +5,8 @@ CREATE TABLE IF NOT EXISTS dgb_gold.pageviews (
   referrer STRING,
   user_agent STRING,
   country STRING,
-  event_timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
-  ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP()
+  event_timestamp TIMESTAMP NOT NULL,
+  ingested_at TIMESTAMP NOT NULL
 )
 PARTITION BY DATE(event_timestamp)
 CLUSTER BY unique_id

--- a/scripts/bigquery/create_tables.sql
+++ b/scripts/bigquery/create_tables.sql
@@ -62,8 +62,11 @@ CREATE TABLE IF NOT EXISTS dgb_gold.dim_temas (
 
 
 -- External table over Bronze raw data in GCS
+-- Note: BigQuery does not support multiple wildcards, so we use a single * at the end.
+-- The Bronze Writer stores files at bronze/news/YYYY/MM/DD/{id}.json but BQ
+-- treats nested paths under a single wildcard correctly.
 CREATE OR REPLACE EXTERNAL TABLE dgb_gold.raw_news_bronze
 OPTIONS (
   format = 'JSON',
-  uris = ['gs://inspire-7-finep-dgb-data-lake/bronze/news/*/*/*/*.json']
+  uris = ['gs://inspire-7-finep-dgb-data-lake/bronze/news/*.json']
 );


### PR DESCRIPTION
## Summary
- Corrige `create_pageviews.sql`: remove `DEFAULT CURRENT_TIMESTAMP()` (não suportado pelo BigQuery DDL)
- Corrige `create_tables.sql`: usa wildcard simples na external table (BigQuery não suporta múltiplos `*`)
- Adiciona workflow `composer-deploy-dags.yaml` para deploy automático de DAGs no Composer

## Contexto
Erros encontrados ao aplicar os SQLs no BigQuery em produção. O workflow de DAGs garante que futuros pushes para `main` que modifiquem `src/data_platform/dags/` façam deploy automático.

## Test plan
- [x] Tabelas BigQuery criadas manualmente com SQL corrigido
- [x] DAGs copiados manualmente para o bucket do Composer
- [ ] Workflow dispara automaticamente em push para main com mudanças em dags/