### PR TITLE
feat: ingestão Umami Analytics → BigQuery

### DIFF
--- a/scripts/bigquery/create_umami_tables.sql
+++ b/scripts/bigquery/create_umami_tables.sql
@@ -1,0 +1,54 @@
+-- Umami Analytics tables for BigQuery
+-- Populated by DAG: sync_umami_to_bigquery
+
+-- Pageviews (event_type=1) enriched with session data
+CREATE TABLE IF NOT EXISTS dgb_gold.umami_pageviews (
+  event_id STRING NOT NULL,
+  session_id STRING NOT NULL,
+  visit_id STRING,
+  created_at TIMESTAMP NOT NULL,
+  url_path STRING,
+  url_query STRING,
+  page_title STRING,
+  referrer_domain STRING,
+  referrer_path STRING,
+  hostname STRING,
+  utm_source STRING,
+  utm_medium STRING,
+  utm_campaign STRING,
+  -- Session data (denormalized)
+  browser STRING,
+  os STRING,
+  device STRING,
+  country STRING,
+  region STRING,
+  city STRING,
+  language STRING
+)
+PARTITION BY DATE(created_at)
+CLUSTER BY url_path
+OPTIONS (
+  description = 'Umami pageview events enriched with session data'
+);
+
+-- Custom events (event_type=2) with event_data as JSON
+CREATE TABLE IF NOT EXISTS dgb_gold.umami_events (
+  event_id STRING NOT NULL,
+  session_id STRING NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  event_name STRING NOT NULL,
+  url_path STRING,
+  hostname STRING,
+  -- Event data (pivoted from key-value pairs)
+  event_data JSON,
+  -- Session data (denormalized)
+  browser STRING,
+  os STRING,
+  device STRING,
+  country STRING
+)
+PARTITION BY DATE(created_at)
+CLUSTER BY event_name
+OPTIONS (
+  description = 'Umami custom events with event_data as JSON'
+);

--- a/src/data_platform/dags/sync_umami_to_bigquery.py
+++ b/src/data_platform/dags/sync_umami_to_bigquery.py
@@ -1,0 +1,117 @@
+"""
+DAG: Sync Umami Analytics → BigQuery.
+
+Schedule: Daily at 9 AM UTC (after sync_pg_to_bigquery at 7 AM and aggregate_engagement at 8 AM).
+Reads pageviews and custom events from Umami's PostgreSQL database and loads
+into BigQuery Gold layer tables (umami_pageviews, umami_events).
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+try:
+    from airflow.decorators import dag, task
+    from airflow.models import Variable
+except ImportError:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+@dag(
+    dag_id="sync_umami_to_bigquery",
+    description="Sync Umami pageviews and custom events from PostgreSQL to BigQuery",
+    schedule="0 9 * * *",
+    start_date=datetime(2025, 1, 1),
+    catchup=False,
+    max_active_runs=1,
+    tags=["data-platform", "bigquery", "umami", "analytics"],
+    default_args={
+        "owner": "data-platform",
+        "retries": 2,
+        "retry_delay": timedelta(minutes=5),
+        "execution_timeout": timedelta(minutes=30),
+    },
+    doc_md="""
+    ### Sync Umami Analytics → BigQuery
+
+    Reads pageview events and custom events from the Umami PostgreSQL database
+    (`umami` database on the same Cloud SQL instance) and loads them into
+    BigQuery tables:
+
+    - `dgb_gold.umami_pageviews` — pageviews enriched with session data
+    - `dgb_gold.umami_events` — custom events with event_data JSON
+
+    **Connection**: Uses Airflow connection `umami_postgres` (user `umami_app`).
+
+    **Schedule**: Daily at 9 AM UTC, syncs previous day's data.
+    """,
+)
+def sync_umami_to_bigquery():
+
+    @task()
+    def sync_pageviews(**context):
+        """Extract pageviews from Umami and load to BigQuery."""
+        from data_platform.jobs.bigquery.umami_sync import (
+            fetch_umami_pageviews,
+            get_umami_db_url,
+            load_to_bigquery,
+            PAGEVIEWS_SCHEMA,
+        )
+
+        db_url = get_umami_db_url()
+        project_id = Variable.get("gcp_project_id", default_var="inspire-7-finep")
+
+        # Date range: previous day (UTC)
+        logical_date = context.get("logical_date") or context.get("execution_date")
+        if logical_date is None:
+            logical_date = datetime.utcnow()
+
+        start_date = (logical_date - timedelta(days=1)).strftime("%Y-%m-%d")
+        end_date = logical_date.strftime("%Y-%m-%d")
+
+        df = fetch_umami_pageviews(db_url, start_date, end_date)
+        if df.empty:
+            return {"status": "no_data", "date": start_date, "rows": 0}
+
+        rows = load_to_bigquery(
+            df, project_id, "dgb_gold.umami_pageviews", PAGEVIEWS_SCHEMA
+        )
+        return {"status": "ok", "date": start_date, "rows": rows}
+
+    @task()
+    def sync_events(**context):
+        """Extract custom events from Umami and load to BigQuery."""
+        from data_platform.jobs.bigquery.umami_sync import (
+            fetch_umami_events,
+            get_umami_db_url,
+            load_to_bigquery,
+            EVENTS_SCHEMA,
+        )
+
+        db_url = get_umami_db_url()
+        project_id = Variable.get("gcp_project_id", default_var="inspire-7-finep")
+
+        # Date range: previous day (UTC)
+        logical_date = context.get("logical_date") or context.get("execution_date")
+        if logical_date is None:
+            logical_date = datetime.utcnow()
+
+        start_date = (logical_date - timedelta(days=1)).strftime("%Y-%m-%d")
+        end_date = logical_date.strftime("%Y-%m-%d")
+
+        df = fetch_umami_events(db_url, start_date, end_date)
+        if df.empty:
+            return {"status": "no_data", "date": start_date, "rows": 0}
+
+        rows = load_to_bigquery(
+            df, project_id, "dgb_gold.umami_events", EVENTS_SCHEMA
+        )
+        return {"status": "ok", "date": start_date, "rows": rows}
+
+    # Tasks run in parallel (pageviews and events are independent)
+    sync_pageviews()
+    sync_events()
+
+
+dag_instance = sync_umami_to_bigquery()

--- a/src/data_platform/jobs/bigquery/engagement.py
+++ b/src/data_platform/jobs/bigquery/engagement.py
@@ -7,13 +7,14 @@ logger = logging.getLogger(__name__)
 
 ENGAGEMENT_QUERY = """
     SELECT
-        unique_id,
+        REGEXP_EXTRACT(url_path, r'/artigos/([a-f0-9]{{32}})') AS unique_id,
         COUNT(*) AS view_count,
         COUNT(DISTINCT session_id) AS unique_sessions
-    FROM `{project_id}.dgb_gold.pageviews`
-    WHERE event_timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {days} DAY)
-    GROUP BY unique_id
-    HAVING COUNT(*) > 0
+    FROM `{project_id}.dgb_gold.umami_pageviews`
+    WHERE created_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {days} DAY)
+      AND url_path LIKE '/artigos/%'
+    GROUP BY 1
+    HAVING unique_id IS NOT NULL
     ORDER BY view_count DESC
 """
 

--- a/src/data_platform/jobs/bigquery/umami_sync.py
+++ b/src/data_platform/jobs/bigquery/umami_sync.py
@@ -1,0 +1,245 @@
+"""Sync Umami Analytics data from PostgreSQL to BigQuery."""
+
+import json
+import logging
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+PAGEVIEWS_QUERY = """
+    SELECT
+        we.event_id::text,
+        we.session_id::text,
+        we.visit_id::text,
+        we.created_at,
+        we.url_path,
+        we.url_query,
+        we.page_title,
+        we.referrer_domain,
+        we.referrer_path,
+        we.hostname,
+        we.utm_source,
+        we.utm_medium,
+        we.utm_campaign,
+        s.browser,
+        s.os,
+        s.device,
+        s.country,
+        s.region,
+        s.city,
+        s.language
+    FROM website_event we
+    JOIN session s ON we.session_id = s.session_id
+    WHERE we.event_type = 1
+      AND we.created_at >= %s
+      AND we.created_at < %s
+    ORDER BY we.created_at
+"""
+
+EVENTS_QUERY = """
+    SELECT
+        we.event_id::text,
+        we.session_id::text,
+        we.created_at,
+        we.event_name,
+        we.url_path,
+        we.hostname,
+        s.browser,
+        s.os,
+        s.device,
+        s.country,
+        jsonb_object_agg(
+            ed.data_key,
+            COALESCE(ed.string_value, ed.number_value::text)
+        ) FILTER (WHERE ed.data_key IS NOT NULL) AS event_data
+    FROM website_event we
+    JOIN session s ON we.session_id = s.session_id
+    LEFT JOIN event_data ed ON we.event_id = ed.website_event_id
+    WHERE we.event_type = 2
+      AND we.created_at >= %s
+      AND we.created_at < %s
+    GROUP BY we.event_id, we.session_id, we.created_at,
+             we.event_name, we.url_path, we.hostname,
+             s.browser, s.os, s.device, s.country
+    ORDER BY we.created_at
+"""
+
+# BigQuery schemas
+PAGEVIEWS_SCHEMA = [
+    ("event_id", "STRING", "REQUIRED"),
+    ("session_id", "STRING", "REQUIRED"),
+    ("visit_id", "STRING", "NULLABLE"),
+    ("created_at", "TIMESTAMP", "REQUIRED"),
+    ("url_path", "STRING", "NULLABLE"),
+    ("url_query", "STRING", "NULLABLE"),
+    ("page_title", "STRING", "NULLABLE"),
+    ("referrer_domain", "STRING", "NULLABLE"),
+    ("referrer_path", "STRING", "NULLABLE"),
+    ("hostname", "STRING", "NULLABLE"),
+    ("utm_source", "STRING", "NULLABLE"),
+    ("utm_medium", "STRING", "NULLABLE"),
+    ("utm_campaign", "STRING", "NULLABLE"),
+    ("browser", "STRING", "NULLABLE"),
+    ("os", "STRING", "NULLABLE"),
+    ("device", "STRING", "NULLABLE"),
+    ("country", "STRING", "NULLABLE"),
+    ("region", "STRING", "NULLABLE"),
+    ("city", "STRING", "NULLABLE"),
+    ("language", "STRING", "NULLABLE"),
+]
+
+EVENTS_SCHEMA = [
+    ("event_id", "STRING", "REQUIRED"),
+    ("session_id", "STRING", "REQUIRED"),
+    ("created_at", "TIMESTAMP", "REQUIRED"),
+    ("event_name", "STRING", "REQUIRED"),
+    ("url_path", "STRING", "NULLABLE"),
+    ("hostname", "STRING", "NULLABLE"),
+    ("event_data", "JSON", "NULLABLE"),
+    ("browser", "STRING", "NULLABLE"),
+    ("os", "STRING", "NULLABLE"),
+    ("device", "STRING", "NULLABLE"),
+    ("country", "STRING", "NULLABLE"),
+]
+
+
+def get_umami_db_url(airflow_conn_id: str = "umami_postgres") -> str:
+    """Build Umami database URL from Airflow connection.
+
+    Uses a dedicated 'umami_postgres' Airflow connection.
+    Falls back to deriving from 'postgres_default' by swapping the database name.
+
+    Args:
+        airflow_conn_id: Airflow connection ID for Umami database
+
+    Returns:
+        SQLAlchemy-compatible connection string
+    """
+    from airflow.hooks.base import BaseHook
+
+    try:
+        conn = BaseHook.get_connection(airflow_conn_id)
+        db_url = conn.get_uri().replace("postgres://", "postgresql://", 1)
+        logger.info(f"Using Airflow connection: {airflow_conn_id}")
+    except Exception:
+        logger.warning(
+            f"Connection '{airflow_conn_id}' not found, "
+            "deriving from 'postgres_default'"
+        )
+        conn = BaseHook.get_connection("postgres_default")
+        db_url = conn.get_uri().replace("postgres://", "postgresql://", 1)
+        db_url = db_url.replace("/govbrnews", "/umami", 1)
+
+    return db_url
+
+
+def fetch_umami_pageviews(
+    db_url: str,
+    start_date: str,
+    end_date: str,
+) -> pd.DataFrame:
+    """Fetch pageview events from Umami PostgreSQL.
+
+    Args:
+        db_url: Umami PostgreSQL connection string
+        start_date: Start datetime (inclusive), ISO format
+        end_date: End datetime (exclusive), ISO format
+
+    Returns:
+        DataFrame with pageview data joined with session info
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import NullPool
+
+    engine = create_engine(db_url, poolclass=NullPool)
+    try:
+        df = pd.read_sql_query(PAGEVIEWS_QUERY, engine, params=(start_date, end_date))
+    finally:
+        engine.dispose()
+
+    logger.info(
+        f"Fetched {len(df)} pageviews from Umami ({start_date} to {end_date})"
+    )
+    return df
+
+
+def fetch_umami_events(
+    db_url: str,
+    start_date: str,
+    end_date: str,
+) -> pd.DataFrame:
+    """Fetch custom events from Umami PostgreSQL.
+
+    Args:
+        db_url: Umami PostgreSQL connection string
+        start_date: Start datetime (inclusive), ISO format
+        end_date: End datetime (exclusive), ISO format
+
+    Returns:
+        DataFrame with custom event data including event_data JSON
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import NullPool
+
+    engine = create_engine(db_url, poolclass=NullPool)
+    try:
+        df = pd.read_sql_query(EVENTS_QUERY, engine, params=(start_date, end_date))
+    finally:
+        engine.dispose()
+
+    # Convert event_data from dict/None to JSON string for BigQuery
+    if not df.empty and "event_data" in df.columns:
+        df["event_data"] = df["event_data"].apply(
+            lambda x: json.dumps(x) if x is not None else None
+        )
+
+    logger.info(
+        f"Fetched {len(df)} custom events from Umami ({start_date} to {end_date})"
+    )
+    return df
+
+
+def load_to_bigquery(
+    df: pd.DataFrame,
+    project_id: str,
+    table_id: str,
+    schema_fields: list[tuple[str, str, str]],
+) -> int:
+    """Load DataFrame into BigQuery table using WRITE_APPEND.
+
+    Args:
+        df: DataFrame to load
+        project_id: GCP project ID
+        table_id: Full table ID (dataset.table)
+        schema_fields: List of (name, type, mode) tuples
+
+    Returns:
+        Number of rows loaded
+    """
+    if df.empty:
+        logger.info(f"No data to load into {table_id}")
+        return 0
+
+    from google.cloud import bigquery
+
+    client = bigquery.Client(project=project_id)
+
+    schema = [
+        bigquery.SchemaField(name, field_type, mode=mode)
+        for name, field_type, mode in schema_fields
+    ]
+
+    job_config = bigquery.LoadJobConfig(
+        schema=schema,
+        write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
+    )
+
+    full_table_id = f"{project_id}.{table_id}"
+    load_job = client.load_table_from_dataframe(
+        df, full_table_id, job_config=job_config
+    )
+    load_job.result()
+
+    logger.info(f"Loaded {load_job.output_rows} rows into {full_table_id}")
+    return load_job.output_rows

--- a/tests/unit/test_engagement.py
+++ b/tests/unit/test_engagement.py
@@ -11,8 +11,12 @@ from data_platform.jobs.bigquery.engagement import (
 
 
 class TestEngagementQuery:
-    def test_query_groups_by_unique_id(self):
-        assert "GROUP BY unique_id" in ENGAGEMENT_QUERY
+    def test_query_reads_from_umami_pageviews(self):
+        assert "umami_pageviews" in ENGAGEMENT_QUERY
+
+    def test_query_extracts_unique_id_from_url_path(self):
+        assert "REGEXP_EXTRACT(url_path" in ENGAGEMENT_QUERY
+        assert "/artigos/" in ENGAGEMENT_QUERY
 
     def test_query_counts_views(self):
         assert "COUNT(*) AS view_count" in ENGAGEMENT_QUERY
@@ -22,6 +26,12 @@ class TestEngagementQuery:
 
     def test_query_uses_project_id_placeholder(self):
         assert "{project_id}" in ENGAGEMENT_QUERY
+
+    def test_query_filters_artigos_path(self):
+        assert "url_path LIKE '/artigos/%'" in ENGAGEMENT_QUERY
+
+    def test_query_filters_null_unique_ids(self):
+        assert "HAVING unique_id IS NOT NULL" in ENGAGEMENT_QUERY
 
 
 class TestBatchUpsertEngagement:

--- a/tests/unit/test_umami_sync.py
+++ b/tests/unit/test_umami_sync.py
@@ -1,0 +1,247 @@
+"""Unit tests for Umami Analytics sync to BigQuery."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from data_platform.jobs.bigquery.umami_sync import (
+    EVENTS_QUERY,
+    EVENTS_SCHEMA,
+    PAGEVIEWS_QUERY,
+    PAGEVIEWS_SCHEMA,
+    fetch_umami_events,
+    fetch_umami_pageviews,
+    load_to_bigquery,
+)
+
+
+class TestPageviewsQuery:
+    def test_filters_event_type_1(self):
+        assert "we.event_type = 1" in PAGEVIEWS_QUERY
+
+    def test_joins_session(self):
+        assert "JOIN session s ON we.session_id = s.session_id" in PAGEVIEWS_QUERY
+
+    def test_has_date_range_params(self):
+        assert "we.created_at >= %s" in PAGEVIEWS_QUERY
+        assert "we.created_at < %s" in PAGEVIEWS_QUERY
+
+    def test_selects_session_fields(self):
+        for field in ["s.browser", "s.os", "s.device", "s.country", "s.region", "s.city", "s.language"]:
+            assert field in PAGEVIEWS_QUERY
+
+    def test_selects_utm_fields(self):
+        for field in ["we.utm_source", "we.utm_medium", "we.utm_campaign"]:
+            assert field in PAGEVIEWS_QUERY
+
+    def test_selects_url_fields(self):
+        for field in ["we.url_path", "we.url_query", "we.page_title"]:
+            assert field in PAGEVIEWS_QUERY
+
+    def test_casts_uuids_to_text(self):
+        assert "we.event_id::text" in PAGEVIEWS_QUERY
+        assert "we.session_id::text" in PAGEVIEWS_QUERY
+        assert "we.visit_id::text" in PAGEVIEWS_QUERY
+
+
+class TestEventsQuery:
+    def test_filters_event_type_2(self):
+        assert "we.event_type = 2" in EVENTS_QUERY
+
+    def test_joins_event_data(self):
+        assert "LEFT JOIN event_data ed ON we.event_id = ed.website_event_id" in EVENTS_QUERY
+
+    def test_aggregates_event_data_as_json(self):
+        assert "jsonb_object_agg" in EVENTS_QUERY
+
+    def test_filters_null_keys(self):
+        assert "WHERE ed.data_key IS NOT NULL" in EVENTS_QUERY
+
+    def test_groups_by_event_fields(self):
+        assert "GROUP BY we.event_id" in EVENTS_QUERY
+
+    def test_has_date_range_params(self):
+        assert "we.created_at >= %s" in EVENTS_QUERY
+        assert "we.created_at < %s" in EVENTS_QUERY
+
+
+class TestSchemas:
+    def test_pageviews_schema_has_all_20_fields(self):
+        assert len(PAGEVIEWS_SCHEMA) == 20
+
+    def test_pageviews_schema_required_modes(self):
+        required = {s[0]: s[2] for s in PAGEVIEWS_SCHEMA}
+        assert required["event_id"] == "REQUIRED"
+        assert required["session_id"] == "REQUIRED"
+        assert required["created_at"] == "REQUIRED"
+        assert required["url_path"] == "NULLABLE"
+
+    def test_events_schema_has_all_11_fields(self):
+        assert len(EVENTS_SCHEMA) == 11
+
+    def test_events_schema_event_data_is_json(self):
+        field = next(s for s in EVENTS_SCHEMA if s[0] == "event_data")
+        assert field[1] == "JSON"
+        assert field[2] == "NULLABLE"
+
+    def test_events_schema_event_name_required(self):
+        field = next(s for s in EVENTS_SCHEMA if s[0] == "event_name")
+        assert field[2] == "REQUIRED"
+
+    def test_pageviews_schema_field_names_match_query_columns(self):
+        """Schema field names should match the columns returned by the SQL query."""
+        schema_names = {s[0] for s in PAGEVIEWS_SCHEMA}
+        # These are the column aliases from the PAGEVIEWS_QUERY
+        expected = {
+            "event_id", "session_id", "visit_id", "created_at",
+            "url_path", "url_query", "page_title", "referrer_domain",
+            "referrer_path", "hostname", "utm_source", "utm_medium",
+            "utm_campaign", "browser", "os", "device", "country",
+            "region", "city", "language",
+        }
+        assert schema_names == expected
+
+    def test_events_schema_field_names_match_query_columns(self):
+        schema_names = {s[0] for s in EVENTS_SCHEMA}
+        expected = {
+            "event_id", "session_id", "created_at", "event_name",
+            "url_path", "hostname", "event_data", "browser", "os",
+            "device", "country",
+        }
+        assert schema_names == expected
+
+
+class TestFetchUmamiPageviews:
+    @patch("sqlalchemy.create_engine")
+    @patch("pandas.read_sql_query")
+    def test_returns_dataframe(self, mock_read_sql, mock_create_engine):
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        expected_df = pd.DataFrame({
+            "event_id": ["id-1"],
+            "session_id": ["sess-1"],
+            "created_at": ["2026-03-01T10:00:00"],
+            "url_path": ["/artigos/abc123"],
+        })
+        mock_read_sql.return_value = expected_df
+
+        result = fetch_umami_pageviews("postgresql://test", "2026-03-01", "2026-03-02")
+
+        assert len(result) == 1
+        assert result.iloc[0]["url_path"] == "/artigos/abc123"
+        mock_read_sql.assert_called_once()
+        mock_engine.dispose.assert_called_once()
+
+    @patch("sqlalchemy.create_engine")
+    @patch("pandas.read_sql_query")
+    def test_passes_date_params(self, mock_read_sql, mock_create_engine):
+        mock_create_engine.return_value = MagicMock()
+        mock_read_sql.return_value = pd.DataFrame()
+
+        fetch_umami_pageviews("postgresql://test", "2026-03-01", "2026-03-02")
+
+        call_args = mock_read_sql.call_args
+        assert call_args[1]["params"] == ("2026-03-01", "2026-03-02")
+
+    @patch("sqlalchemy.create_engine")
+    @patch("pandas.read_sql_query")
+    def test_disposes_engine_on_error(self, mock_read_sql, mock_create_engine):
+        mock_engine = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_read_sql.side_effect = Exception("DB error")
+
+        with pytest.raises(Exception, match="DB error"):
+            fetch_umami_pageviews("postgresql://test", "2026-03-01", "2026-03-02")
+
+        mock_engine.dispose.assert_called_once()
+
+
+class TestFetchUmamiEvents:
+    @patch("sqlalchemy.create_engine")
+    @patch("pandas.read_sql_query")
+    def test_converts_event_data_to_json_string(self, mock_read_sql, mock_create_engine):
+        mock_create_engine.return_value = MagicMock()
+        mock_read_sql.return_value = pd.DataFrame({
+            "event_id": ["id-1"],
+            "session_id": ["sess-1"],
+            "created_at": ["2026-03-01T10:00:00"],
+            "event_name": ["article_click"],
+            "url_path": ["/artigos/abc123"],
+            "hostname": ["example.com"],
+            "browser": ["chrome"],
+            "os": ["Mac OS"],
+            "device": ["laptop"],
+            "country": ["BR"],
+            "event_data": [{"article_id": "abc123", "origin": "home"}],
+        })
+
+        result = fetch_umami_events("postgresql://test", "2026-03-01", "2026-03-02")
+
+        data = json.loads(result.iloc[0]["event_data"])
+        assert data["article_id"] == "abc123"
+        assert data["origin"] == "home"
+
+    @patch("sqlalchemy.create_engine")
+    @patch("pandas.read_sql_query")
+    def test_handles_null_event_data(self, mock_read_sql, mock_create_engine):
+        mock_create_engine.return_value = MagicMock()
+        mock_read_sql.return_value = pd.DataFrame({
+            "event_id": ["id-1"],
+            "session_id": ["sess-1"],
+            "created_at": ["2026-03-01T10:00:00"],
+            "event_name": ["button_click"],
+            "url_path": ["/"],
+            "hostname": ["example.com"],
+            "browser": ["chrome"],
+            "os": ["Mac OS"],
+            "device": ["laptop"],
+            "country": ["BR"],
+            "event_data": [None],
+        })
+
+        result = fetch_umami_events("postgresql://test", "2026-03-01", "2026-03-02")
+
+        assert result.iloc[0]["event_data"] is None
+
+    @patch("sqlalchemy.create_engine")
+    @patch("pandas.read_sql_query")
+    def test_empty_dataframe_returns_empty(self, mock_read_sql, mock_create_engine):
+        mock_create_engine.return_value = MagicMock()
+        mock_read_sql.return_value = pd.DataFrame()
+
+        result = fetch_umami_events("postgresql://test", "2026-03-01", "2026-03-02")
+
+        assert result.empty
+
+
+class TestLoadToBigquery:
+    def test_empty_dataframe_returns_zero(self):
+        df = pd.DataFrame()
+        result = load_to_bigquery(df, "my-project", "dgb_gold.umami_pageviews", PAGEVIEWS_SCHEMA)
+        assert result == 0
+
+    @patch("google.cloud.bigquery.Client")
+    @patch("google.cloud.bigquery.LoadJobConfig")
+    @patch("google.cloud.bigquery.SchemaField")
+    @patch("google.cloud.bigquery.WriteDisposition")
+    def test_loads_dataframe_to_correct_table(
+        self, mock_wd, mock_sf, mock_config, mock_client_cls
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_job = MagicMock()
+        mock_job.output_rows = 5
+        mock_client.load_table_from_dataframe.return_value = mock_job
+
+        df = pd.DataFrame({
+            "event_id": ["id-1", "id-2"],
+            "session_id": ["s-1", "s-2"],
+        })
+
+        result = load_to_bigquery(df, "my-project", "dgb_gold.umami_pageviews", PAGEVIEWS_SCHEMA)
+
+        assert result == 5
+        call_args = mock_client.load_table_from_dataframe.call_args
+        assert call_args[0][1] == "my-project.dgb_gold.umami_pageviews"


### PR DESCRIPTION
## Summary

- Adiciona DAG `sync_umami_to_bigquery` para sincronizar dados do Umami Analytics (pageviews + custom events) do PostgreSQL para o BigQuery
- Cria job `umami_sync.py` com queries validadas contra o banco de produção do Umami
- Atualiza `engagement.py` para ler de `umami_pageviews` em vez de `pageviews` (tabela vazia)
- 28 testes unitários novos + 7 testes atualizados

## Detalhes

### Novas tabelas BigQuery
- `dgb_gold.umami_pageviews` — pageviews enriquecidos com dados de sessão (browser, device, país, UTMs)
- `dgb_gold.umami_events` — custom events com event_data como JSON

### DAG
- Schedule: diária às 9h UTC
- 2 tasks paralelas: `sync_pageviews` + `sync_events`
- Usa Airflow connection `umami_postgres` (já criada no Composer)

### Descobertas durante validação
- URL dos artigos no portal é `/artigos/{unique_id}` (regex ajustado)
- User `govbrnews_app` não tem permissão no database `umami` — necessário usar `umami_app` via connection dedicada

## Test plan
- [x] Queries testadas diretamente no PostgreSQL de produção (Umami)
- [x] 28 testes unitários passando (`poetry run pytest tests/unit/test_umami_sync.py`)
- [x] 7 testes do engagement atualizados e passando
- [ ] Executar DDL: `bq query < scripts/bigquery/create_umami_tables.sql`
- [ ] Trigger manual da DAG no Composer após deploy
- [ ] Verificar dados em `dgb_gold.umami_pageviews`

🤖 Generated with [Claude Code](https://claude.com/claude-code)