### PR TITLE
docs: atualiza .env.example com connection umami_postgres

### DIFF
--- a/airflow/.env.example
+++ b/airflow/.env.example
@@ -1,0 +1,11 @@
+# Airflow Connections (AIRFLOW_CONN_{CONN_ID} format)
+AIRFLOW_CONN_POSTGRES_DEFAULT=postgresql://govbrnews_app:PASSWORD@34.39.145.55:5432/govbrnews
+
+# Umami Analytics PostgreSQL (via Cloud SQL Proxy on host)
+# Local: proxy na porta 5433 → host.docker.internal
+# Composer: via Secret Manager (airflow-connections-umami_postgres)
+AIRFLOW_CONN_UMAMI_POSTGRES=postgresql://umami_app:PASSWORD@host.docker.internal:5433/umami
+
+# Airflow Variables
+AIRFLOW_VAR_GCP_PROJECT_ID=inspire-7-finep
+AIRFLOW_VAR_DATA_LAKE_BUCKET=inspire-7-finep-dgb-data-lake


### PR DESCRIPTION
## Summary
- Adiciona `AIRFLOW_CONN_UMAMI_POSTGRES` ao `.env.example` com placeholder
- Documenta diferença entre uso local (Cloud SQL Proxy) e Composer (Secret Manager)

🤖 Generated with [Claude Code](https://claude.com/claude-code)