### PR TITLE
fix: envolver query com sqlalchemy.text() no batch.py

### DIFF
--- a/src/data_platform/jobs/thumbnail/batch.py
+++ b/src/data_platform/jobs/thumbnail/batch.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 
 import pandas as pd
+from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
 logger = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ def fetch_articles_needing_thumbnails(
     Returns:
         List of dicts: [{unique_id, video_url}, ...]
     """
-    df = pd.read_sql_query(QUERY, engine, params={"batch_size": batch_size})
+    df = pd.read_sql_query(text(QUERY), engine, params={"batch_size": batch_size})
 
     if df.empty:
         logger.info("No articles needing thumbnails")


### PR DESCRIPTION
## Resumo

- `pd.read_sql_query` com psycopg2 nao resolve named parameters (`:batch_size`) quando a query e passada como string raw
- Envolver a query em `sqlalchemy.text()` permite a substituicao correta dos parametros
- Sem este fix, a DAG `generate_video_thumbnails` falha ao executar o batch

## Contexto

Continuacao dos fixes pos-merge do PR #119 (thumbnail worker):
- #122 — modulo nao copiado para o bucket de plugins
- #123 — loguru nao disponivel no Composer
- Este PR — named params nao resolvidos pelo psycopg2

## Relacionado

- Issue: #21
- Follow-ups: #120