### PR TITLE
feat: workflow de deploy do thumbnail worker

### DIFF
--- a/.github/workflows/thumbnail-worker-deploy.yaml
+++ b/.github/workflows/thumbnail-worker-deploy.yaml
@@ -1,0 +1,25 @@
+name: Deploy Thumbnail Worker
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'src/data_platform/workers/thumbnail_worker/**'
+      - 'docker/thumbnail-worker/**'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.github/workflows/thumbnail-worker-deploy.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    uses: destaquesgovbr/reusable-workflows/.github/workflows/cloud-run-deploy.yml@v2
+    with:
+      dockerfile: docker/thumbnail-worker/Dockerfile
+      ar_repository: destaquesgovbr-thumbnail-worker
+      image_name: thumbnail-worker
+      cloud_run_service: destaquesgovbr-thumbnail-worker


### PR DESCRIPTION
## Summary

- Cria `.github/workflows/thumbnail-worker-deploy.yaml` para build e deploy do thumbnail-worker no Cloud Run
- Usa reusable workflow `destaquesgovbr/reusable-workflows/.github/workflows/cloud-run-deploy.yml@v2`
- Trigger: push em main nos paths do worker + workflow_dispatch

Parte de #21 (geracao automatica de thumbnails para noticias de video).

## Dependencia

Requer que destaquesgovbr/infra#169 seja aplicado primeiro para que o Artifact Registry e Cloud Run service existam.

## Test plan

- [ ] Merge infra PR e aplicar terraform
- [ ] Merge este PR
- [ ] Trigger manual via workflow_dispatch
- [ ] Verificar que imagem Docker e buildada e pushada para Artifact Registry
- [ ] Cloud Run service atualizado com a imagem correta
- [ ] `/health` responde `{"status": "ok"}`