### PR TITLE
feat: melhorias de robustez e performance no thumbnail worker

### DIFF
--- a/scripts/migrations/007_create_idx_news_video_no_image.sql
+++ b/scripts/migrations/007_create_idx_news_video_no_image.sql
@@ -1,0 +1,10 @@
+-- 007_create_idx_news_video_no_image.sql
+-- Indice parcial para otimizar a query de batch de thumbnails.
+-- Cobre o ORDER BY (published_at DESC, unique_id ASC) e o WHERE parcial
+-- usado em jobs/thumbnail/batch.py.
+
+CREATE INDEX IF NOT EXISTS idx_news_video_no_image
+    ON news (published_at DESC, unique_id ASC)
+    WHERE video_url IS NOT NULL
+      AND video_url != ''
+      AND (image_url IS NULL OR image_url = '');

--- a/scripts/migrations/007_create_idx_news_video_no_image_rollback.sql
+++ b/scripts/migrations/007_create_idx_news_video_no_image_rollback.sql
@@ -1,0 +1,3 @@
+-- Rollback for 007_create_idx_news_video_no_image.sql
+
+DROP INDEX IF EXISTS idx_news_video_no_image;

--- a/src/data_platform/dags/generate_video_thumbnails.py
+++ b/src/data_platform/dags/generate_video_thumbnails.py
@@ -7,6 +7,7 @@ via Cloud Run thumbnail-worker.
 """
 
 import base64
+import concurrent.futures
 import json
 import logging
 from datetime import datetime, timedelta
@@ -20,6 +21,42 @@ from airflow.models import Variable
 logger = logging.getLogger(__name__)
 
 WORKER_REQUEST_TIMEOUT = 60
+
+
+def _process_one(article: dict, worker_url: str) -> tuple[str, str]:
+    """Envia um artigo para o thumbnail worker. Retorna (unique_id, status).
+
+    Args:
+        article: Dict with unique_id key.
+        worker_url: Base URL of the thumbnail worker.
+
+    Returns:
+        Tuple of (unique_id, status).
+    """
+    unique_id = article["unique_id"]
+    try:
+        resp = requests.post(
+            f"{worker_url}/process",
+            json={
+                "message": {
+                    "data": base64.b64encode(
+                        json.dumps({"unique_id": unique_id}).encode()
+                    ).decode(),
+                    "attributes": {},
+                }
+            },
+            timeout=WORKER_REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        result = (
+            resp.json()
+            if resp.headers.get("content-type", "").startswith("application/json")
+            else {}
+        )
+        return unique_id, result.get("status", "unknown")
+    except Exception as e:
+        logger.error(f"Erro ao processar {unique_id}: {e}")
+        return unique_id, "failed"
 
 
 @dag(
@@ -60,9 +97,11 @@ def generate_video_thumbnails_dag():
         from sqlalchemy.pool import NullPool
 
         engine = create_engine(db_url, poolclass=NullPool)
-
-        batch_size = int(Variable.get("thumbnail_batch_size", default_var="100"))
-        articles = fetch_articles_needing_thumbnails(engine, batch_size=batch_size)
+        try:
+            batch_size = int(Variable.get("thumbnail_batch_size", default_var="100"))
+            articles = fetch_articles_needing_thumbnails(engine, batch_size=batch_size)
+        finally:
+            engine.dispose()
 
         if not articles:
             logger.info("Nenhum artigo para gerar thumbnail")
@@ -73,41 +112,22 @@ def generate_video_thumbnails_dag():
 
     @task()
     def generate_thumbnails(articles: list[dict]):
-        """Envia artigos para o Thumbnail Worker via HTTP."""
+        """Envia artigos para o Thumbnail Worker via HTTP (paralelo)."""
         if not articles:
             return {"processed": 0, "generated": 0, "failed": 0, "skipped": 0}
 
         worker_url = Variable.get("thumbnail_worker_url")
+        max_workers = int(Variable.get("thumbnail_max_workers", default_var="5"))
         summary = {"processed": 0, "generated": 0, "failed": 0, "skipped": 0}
 
-        for article in articles:
-            unique_id = article["unique_id"]
-            try:
-                resp = requests.post(
-                    f"{worker_url}/process",
-                    json={
-                        "message": {
-                            "data": base64.b64encode(
-                                json.dumps({"unique_id": unique_id}).encode()
-                            ).decode(),
-                            "attributes": {},
-                        }
-                    },
-                    timeout=WORKER_REQUEST_TIMEOUT,
-                )
-                resp.raise_for_status()
-                result = (
-                    resp.json()
-                    if resp.headers.get("content-type", "").startswith("application/json")
-                    else {}
-                )
-                status = result.get("status", "unknown")
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(_process_one, article, worker_url): article for article in articles
+            }
+            for future in concurrent.futures.as_completed(futures):
+                unique_id, status = future.result()
                 summary[status] = summary.get(status, 0) + 1
-            except Exception as e:
-                logger.error(f"Erro ao processar {unique_id}: {e}")
-                summary["failed"] += 1
-
-            summary["processed"] += 1
+                summary["processed"] += 1
 
         return summary
 

--- a/src/data_platform/jobs/thumbnail/batch.py
+++ b/src/data_platform/jobs/thumbnail/batch.py
@@ -23,7 +23,7 @@ QUERY = """
           nf.unique_id IS NULL
           OR (nf.features->>'thumbnail_failed')::boolean IS NOT TRUE
       )
-    ORDER BY n.published_at DESC
+    ORDER BY n.published_at DESC, n.unique_id ASC
     LIMIT :batch_size
 """
 

--- a/src/data_platform/workers/thumbnail_worker/app.py
+++ b/src/data_platform/workers/thumbnail_worker/app.py
@@ -8,6 +8,8 @@ without images, and stores them in GCS.
 import base64
 import json
 import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -19,16 +21,16 @@ from data_platform.workers.thumbnail_worker.handler import handle_thumbnail_gene
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="Thumbnail Worker", version="1.0.0")
 
-_pg: PostgresManager | None = None
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Initialize PostgresManager on startup, close on shutdown."""
+    app.state.pg = PostgresManager()
+    yield
+    app.state.pg.close_all()
 
 
-def _get_pg() -> PostgresManager:
-    global _pg
-    if _pg is None:
-        _pg = PostgresManager()
-    return _pg
+app = FastAPI(title="Thumbnail Worker", version="1.0.0", lifespan=lifespan)
 
 
 @app.get("/health")
@@ -65,7 +67,8 @@ async def process(request: Request):
     bucket_name = settings.gcs_bucket
 
     try:
-        result = handle_thumbnail_generation(unique_id, _get_pg(), bucket_name)
+        pg = request.app.state.pg
+        result = handle_thumbnail_generation(unique_id, pg, bucket_name)
         logger.info(f"Result for {unique_id}: {result['status']}")
         return JSONResponse(content=result)
     except Exception as e:

--- a/src/data_platform/workers/thumbnail_worker/extractor.py
+++ b/src/data_platform/workers/thumbnail_worker/extractor.py
@@ -5,6 +5,7 @@ Pure wrapper around ffmpeg subprocess — no database or storage I/O.
 
 import subprocess
 from dataclasses import dataclass
+from urllib.parse import urlparse, urlunparse
 
 from loguru import logger
 
@@ -28,6 +29,20 @@ class ThumbnailExtractionResult:
 
 
 ALLOWED_SCHEMES = ("http://", "https://")
+JPEG_SOI = b"\xff\xd8"
+
+
+def _sanitize_url(url: str) -> str:
+    """Strip query params and fragment from URL for safe logging.
+
+    Args:
+        url: Full URL possibly containing auth query params.
+
+    Returns:
+        URL with only scheme, netloc, and path preserved.
+    """
+    parsed = urlparse(url)
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
 
 
 def _validate_video_url(video_url: str) -> None:
@@ -39,7 +54,7 @@ def _validate_video_url(video_url: str) -> None:
         ThumbnailExtractionError: If URL scheme is not HTTP(S).
     """
     if not video_url.lower().startswith(ALLOWED_SCHEMES):
-        raise ThumbnailExtractionError(f"Invalid URL scheme: {video_url[:50]}")
+        raise ThumbnailExtractionError(f"Invalid URL scheme: {_sanitize_url(video_url)[:50]}")
 
 
 def build_ffmpeg_command(video_url: str, width: int, height: int) -> list[str]:
@@ -96,25 +111,29 @@ def extract_first_frame(
     """
     _validate_video_url(video_url)
     cmd = build_ffmpeg_command(video_url, width, height)
-    logger.info(f"Extracting thumbnail from {video_url} ({width}x{height})")
+    safe_url = _sanitize_url(video_url)
+    logger.info(f"Extracting thumbnail from {safe_url} ({width}x{height})")
 
     try:
         result = subprocess.run(cmd, capture_output=True, timeout=timeout_seconds)
     except subprocess.TimeoutExpired as e:
         raise ThumbnailExtractionError(
-            f"ffmpeg timeout after {timeout_seconds}s for {video_url}"
+            f"ffmpeg timeout after {timeout_seconds}s for {safe_url}"
         ) from e
 
     if result.returncode != 0:
         stderr = result.stderr.decode(errors="replace")
         raise ThumbnailExtractionError(
-            f"ffmpeg exit code {result.returncode} for {video_url}: {stderr[:200]}"
+            f"ffmpeg exit code {result.returncode} for {safe_url}: {stderr[:200]}"
         )
 
     if not result.stdout:
-        raise ThumbnailExtractionError(f"ffmpeg produced empty output for {video_url}")
+        raise ThumbnailExtractionError(f"ffmpeg produced empty output for {safe_url}")
 
-    logger.info(f"Extracted {len(result.stdout)} bytes from {video_url}")
+    if result.stdout[:2] != JPEG_SOI:
+        raise ThumbnailExtractionError(f"ffmpeg output is not valid JPEG for {safe_url}")
+
+    logger.info(f"Extracted {len(result.stdout)} bytes from {safe_url}")
 
     return ThumbnailExtractionResult(
         image_bytes=result.stdout,

--- a/tests/unit/test_dag_thumbnail.py
+++ b/tests/unit/test_dag_thumbnail.py
@@ -1,0 +1,170 @@
+"""Unit tests for generate_video_thumbnails DAG.
+
+Airflow is not installed locally and the DAG module executes
+dag_instance = generate_video_thumbnails_dag() at import time,
+so we use AST-based structural tests and exec-based isolation
+for testing the _process_one helper.
+"""
+
+import ast
+import base64
+import json
+import textwrap
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+DAG_FILE = Path("src/data_platform/dags/generate_video_thumbnails.py")
+
+
+def _parse_dag_ast() -> ast.Module:
+    """Parse the DAG file AST for structural tests."""
+    return ast.parse(DAG_FILE.read_text())
+
+
+class TestFetchBatchEngineDispose:
+    """Verify that fetch_batch wraps engine usage in try/finally with dispose."""
+
+    def test_engine_dispose_in_finally_block(self) -> None:
+        """engine.dispose() must be called in a finally block."""
+        tree = _parse_dag_ast()
+
+        fetch_batch_fn = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "fetch_batch":
+                fetch_batch_fn = node
+                break
+
+        assert fetch_batch_fn is not None, "fetch_batch function not found"
+
+        has_try_finally = False
+        for node in ast.walk(fetch_batch_fn):
+            if isinstance(node, ast.Try) and node.finalbody:
+                for stmt in node.finalbody:
+                    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+                        call = stmt.value
+                        if isinstance(call.func, ast.Attribute) and call.func.attr == "dispose":
+                            has_try_finally = True
+
+        assert (
+            has_try_finally
+        ), "fetch_batch must wrap engine usage in try/finally with engine.dispose()"
+
+
+class TestGenerateThumbnailsParallel:
+    """Verify that generate_thumbnails uses ThreadPoolExecutor."""
+
+    def test_uses_thread_pool_executor(self) -> None:
+        """generate_thumbnails must use ThreadPoolExecutor for parallel processing."""
+        tree = _parse_dag_ast()
+
+        gen_fn = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "generate_thumbnails":
+                gen_fn = node
+                break
+
+        assert gen_fn is not None, "generate_thumbnails function not found"
+
+        source = DAG_FILE.read_text()
+        fn_source = ast.get_source_segment(source, gen_fn)
+        assert "ThreadPoolExecutor" in fn_source, "generate_thumbnails must use ThreadPoolExecutor"
+
+    def test_has_process_one_function(self) -> None:
+        """A _process_one helper must exist at module level for testability."""
+        tree = _parse_dag_ast()
+
+        found = False
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_process_one":
+                found = True
+                break
+
+        assert found, "_process_one function must exist at module level"
+
+
+def _load_process_one():
+    """Load _process_one from DAG source without importing airflow.
+
+    Extracts the function source + its dependencies and exec's them
+    in an isolated namespace.
+    """
+    source = DAG_FILE.read_text()
+    tree = ast.parse(source)
+
+    # Find _process_one function node
+    fn_node = None
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_process_one":
+            fn_node = node
+            break
+
+    if fn_node is None:
+        return None
+
+    fn_source = ast.get_source_segment(source, fn_node)
+
+    # Build a minimal namespace with required imports
+    ns: dict = {}
+    exec(
+        textwrap.dedent(
+            """
+        import base64
+        import json
+        import logging
+        import requests
+
+        logger = logging.getLogger("test")
+        WORKER_REQUEST_TIMEOUT = 60
+        """
+        ),
+        ns,
+    )
+    exec(fn_source, ns)
+    return ns["_process_one"]
+
+
+class TestProcessOne:
+    """Tests for the _process_one helper function."""
+
+    @pytest.fixture()
+    def process_one(self):
+        fn = _load_process_one()
+        if fn is None:
+            pytest.skip("_process_one not found in DAG source")
+        return fn
+
+    @patch("requests.post")
+    def test_returns_status_on_success(self, mock_post, process_one) -> None:
+        mock_post.return_value = Mock(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            json=Mock(return_value={"status": "generated"}),
+            raise_for_status=Mock(),
+        )
+        uid, status = process_one({"unique_id": "a1"}, "http://worker")
+        assert uid == "a1"
+        assert status == "generated"
+
+    @patch("requests.post")
+    def test_returns_failed_on_exception(self, mock_post, process_one) -> None:
+        mock_post.side_effect = Exception("connection refused")
+        uid, status = process_one({"unique_id": "a1"}, "http://worker")
+        assert uid == "a1"
+        assert status == "failed"
+
+    @patch("requests.post")
+    def test_sends_correct_pubsub_envelope(self, mock_post, process_one) -> None:
+        mock_post.return_value = Mock(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            json=Mock(return_value={"status": "generated"}),
+            raise_for_status=Mock(),
+        )
+        process_one({"unique_id": "test_uid"}, "http://worker")
+
+        call_kwargs = mock_post.call_args[1]
+        envelope = call_kwargs["json"]
+        decoded = json.loads(base64.b64decode(envelope["message"]["data"]))
+        assert decoded == {"unique_id": "test_uid"}

--- a/tests/unit/test_thumbnail_app.py
+++ b/tests/unit/test_thumbnail_app.py
@@ -4,7 +4,7 @@ import base64
 import json
 from unittest.mock import Mock, patch
 
-from data_platform.workers.thumbnail_worker.app import app
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -14,73 +14,115 @@ def _make_pubsub_envelope(unique_id: str) -> dict:
     return {"message": {"data": data, "attributes": {}}}
 
 
+@pytest.fixture()
+def _mock_pg():
+    """Mock PostgresManager so lifespan doesn't connect to a real DB."""
+    with patch("data_platform.workers.thumbnail_worker.app.PostgresManager") as MockPG:
+        mock_pg = Mock()
+        MockPG.return_value = mock_pg
+        yield mock_pg
+
+
 class TestHealthEndpoint:
     """Tests for GET /health."""
 
+    @pytest.mark.usefixtures("_mock_pg")
     def test_returns_200(self) -> None:
-        client = TestClient(app)
-        resp = client.get("/health")
+        from data_platform.workers.thumbnail_worker.app import app
+
+        with TestClient(app) as client:
+            resp = client.get("/health")
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
+
+
+class TestLifespan:
+    """Tests for FastAPI lifespan (PG connection management)."""
+
+    def test_lifespan_closes_pg_on_shutdown(self) -> None:
+        """close_all is called when the app shuts down."""
+        with patch("data_platform.workers.thumbnail_worker.app.PostgresManager") as MockPG:
+            mock_pg = Mock()
+            MockPG.return_value = mock_pg
+
+            from data_platform.workers.thumbnail_worker.app import app
+
+            with TestClient(app):
+                pass  # triggers startup + shutdown
+
+        mock_pg.close_all.assert_called_once()
 
 
 class TestProcessEndpoint:
     """Tests for POST /process."""
 
+    @pytest.mark.usefixtures("_mock_pg")
     @patch("data_platform.workers.thumbnail_worker.app.handle_thumbnail_generation")
-    @patch("data_platform.workers.thumbnail_worker.app._get_pg")
-    def test_decodes_pubsub_envelope(self, mock_get_pg, mock_handler) -> None:
+    def test_decodes_pubsub_envelope(self, mock_handler) -> None:
         mock_handler.return_value = {"status": "generated"}
-        mock_get_pg.return_value = Mock()
 
-        client = TestClient(app)
-        resp = client.post("/process", json=_make_pubsub_envelope("uid_123"))
+        from data_platform.workers.thumbnail_worker.app import app
+
+        with TestClient(app) as client:
+            resp = client.post("/process", json=_make_pubsub_envelope("uid_123"))
 
         assert resp.status_code == 200
         mock_handler.assert_called_once()
         args = mock_handler.call_args[0]
         assert args[0] == "uid_123"
 
+    @pytest.mark.usefixtures("_mock_pg")
     def test_returns_400_for_invalid_json(self) -> None:
-        client = TestClient(app)
-        resp = client.post(
-            "/process", content=b"not json", headers={"content-type": "application/json"}
-        )
+        from data_platform.workers.thumbnail_worker.app import app
+
+        with TestClient(app) as client:
+            resp = client.post(
+                "/process", content=b"not json", headers={"content-type": "application/json"}
+            )
         assert resp.status_code == 400
 
+    @pytest.mark.usefixtures("_mock_pg")
     def test_returns_400_for_missing_data(self) -> None:
-        client = TestClient(app)
-        resp = client.post("/process", json={"message": {}})
+        from data_platform.workers.thumbnail_worker.app import app
+
+        with TestClient(app) as client:
+            resp = client.post("/process", json={"message": {}})
         assert resp.status_code == 400
 
+    @pytest.mark.usefixtures("_mock_pg")
     def test_returns_400_for_missing_unique_id(self) -> None:
         data = base64.b64encode(json.dumps({"foo": "bar"}).encode()).decode()
-        client = TestClient(app)
-        resp = client.post("/process", json={"message": {"data": data}})
+
+        from data_platform.workers.thumbnail_worker.app import app
+
+        with TestClient(app) as client:
+            resp = client.post("/process", json={"message": {"data": data}})
         assert resp.status_code == 400
 
+    @pytest.mark.usefixtures("_mock_pg")
     @patch("data_platform.workers.thumbnail_worker.app.handle_thumbnail_generation")
-    @patch("data_platform.workers.thumbnail_worker.app._get_pg")
-    def test_returns_json_content_type(self, mock_get_pg, mock_handler) -> None:
+    def test_returns_json_content_type(self, mock_handler) -> None:
         mock_handler.return_value = {"status": "generated"}
-        mock_get_pg.return_value = Mock()
 
-        client = TestClient(app)
-        resp = client.post("/process", json=_make_pubsub_envelope("uid_123"))
+        from data_platform.workers.thumbnail_worker.app import app
+
+        with TestClient(app) as client:
+            resp = client.post("/process", json=_make_pubsub_envelope("uid_123"))
 
         assert resp.status_code == 200
         assert resp.headers["content-type"].startswith("application/json")
         assert resp.json() == {"status": "generated"}
 
+    @pytest.mark.usefixtures("_mock_pg")
     @patch("data_platform.workers.thumbnail_worker.app.handle_thumbnail_generation")
-    @patch("data_platform.workers.thumbnail_worker.app._get_pg")
-    def test_returns_200_ack_on_unhandled_error(self, mock_get_pg, mock_handler) -> None:
+    def test_returns_200_ack_on_unhandled_error(self, mock_handler) -> None:
         """Unhandled errors return 200 to ACK the Pub/Sub message (avoid infinite retry)."""
         mock_handler.side_effect = RuntimeError("DB connection lost")
-        mock_get_pg.return_value = Mock()
 
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/process", json=_make_pubsub_envelope("uid_123"))
+        from data_platform.workers.thumbnail_worker.app import app
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/process", json=_make_pubsub_envelope("uid_123"))
 
         assert resp.status_code == 200
         assert resp.json()["status"] == "error"

--- a/tests/unit/test_thumbnail_batch.py
+++ b/tests/unit/test_thumbnail_batch.py
@@ -38,7 +38,19 @@ class TestFetchArticlesNeedingThumbnails:
 
         fetch_articles_needing_thumbnails(mock_engine, batch_size=50)
 
-        assert "thumbnail_failed" in mock_read_sql.call_args[0][0]
+        query_text = str(mock_read_sql.call_args[0][0])
+        assert "thumbnail_failed" in query_text
+
+    @patch("data_platform.jobs.thumbnail.batch.pd.read_sql_query")
+    def test_query_has_deterministic_order(self, mock_read_sql) -> None:
+        """ORDER BY must include tiebreaker for deterministic pagination."""
+        mock_read_sql.return_value = pd.DataFrame(columns=["unique_id", "video_url"])
+        mock_engine = Mock()
+
+        fetch_articles_needing_thumbnails(mock_engine, batch_size=10)
+
+        query_text = str(mock_read_sql.call_args[0][0])
+        assert "n.unique_id ASC" in query_text
 
     @patch("data_platform.jobs.thumbnail.batch.pd.read_sql_query")
     def test_respects_batch_size(self, mock_read_sql) -> None:

--- a/tests/unit/test_thumbnail_extractor.py
+++ b/tests/unit/test_thumbnail_extractor.py
@@ -8,6 +8,7 @@ import pytest
 from data_platform.workers.thumbnail_worker.extractor import (
     ThumbnailExtractionError,
     ThumbnailExtractionResult,
+    _sanitize_url,
     _validate_video_url,
     build_ffmpeg_command,
     extract_first_frame,
@@ -15,6 +16,27 @@ from data_platform.workers.thumbnail_worker.extractor import (
 
 # Minimal valid JPEG: SOI marker (0xFFD8) + APP0 + EOI marker (0xFFD9)
 FAKE_JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"\x00" * 100 + b"\xff\xd9"
+
+
+class TestSanitizeUrl:
+    """Tests for _sanitize_url (log-safe URL stripping)."""
+
+    def test_strips_query_params(self) -> None:
+        result = _sanitize_url("https://cdn.ebc.com.br/video.mp4?token=SECRET&sig=abc")
+        assert result == "https://cdn.ebc.com.br/video.mp4"
+        assert "SECRET" not in result
+
+    def test_strips_fragment(self) -> None:
+        result = _sanitize_url("https://example.com/video.mp4#section")
+        assert result == "https://example.com/video.mp4"
+
+    def test_preserves_url_without_query(self) -> None:
+        result = _sanitize_url("https://example.com/path/video.mp4")
+        assert result == "https://example.com/path/video.mp4"
+
+    def test_handles_empty_url(self) -> None:
+        result = _sanitize_url("")
+        assert isinstance(result, str)
 
 
 class TestValidateVideoUrl:
@@ -145,3 +167,29 @@ class TestExtractFirstFrame:
         mock_run.assert_called_once()
         _, kwargs = mock_run.call_args
         assert kwargs["timeout"] == 60
+
+    @patch("data_platform.workers.thumbnail_worker.extractor.subprocess.run")
+    def test_non_jpeg_output_raises_extraction_error(self, mock_run) -> None:
+        """ffmpeg output that doesn't start with JPEG SOI marker is rejected."""
+        mock_run.return_value = CompletedProcess(
+            args=[], returncode=0, stdout=b"GIF89a" + b"\x00" * 100, stderr=b""
+        )
+        with pytest.raises(ThumbnailExtractionError, match="not valid JPEG"):
+            extract_first_frame("http://example.com/video.mp4")
+
+    @patch("data_platform.workers.thumbnail_worker.extractor.subprocess.run")
+    def test_random_bytes_output_raises_extraction_error(self, mock_run) -> None:
+        """Random bytes that are not JPEG must be rejected."""
+        mock_run.return_value = CompletedProcess(
+            args=[], returncode=0, stdout=b"\x00\x01\x02\x03" * 25, stderr=b""
+        )
+        with pytest.raises(ThumbnailExtractionError, match="not valid JPEG"):
+            extract_first_frame("http://example.com/video.mp4")
+
+    @patch("data_platform.workers.thumbnail_worker.extractor.subprocess.run")
+    def test_error_message_does_not_leak_query_params(self, mock_run) -> None:
+        """Error messages must not contain URL query parameters."""
+        mock_run.return_value = CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        with pytest.raises(ThumbnailExtractionError) as exc_info:
+            extract_first_frame("http://example.com/video.mp4?token=SECRET")
+        assert "SECRET" not in str(exc_info.value)


### PR DESCRIPTION
## Resumo

Implementa os **7 itens de melhoria** identificados nas code reviews do PR #119, consolidados na issue #120. Foco em robustez, seguranca de logs e performance do thumbnail worker em producao.

**Issue**: closes #120
**Relacionadas**: #21, #119, #124

## Alteracoes

### 1. FastAPI lifespan para cleanup de conexoes PG
- **Arquivo**: `src/data_platform/workers/thumbnail_worker/app.py`
- Singleton global `_pg` substituido por `lifespan` async context manager
- `PostgresManager.close_all()` chamado automaticamente no shutdown do container Cloud Run
- Previne conexoes PG orfas quando instancias escalam para zero

### 2. `engine.dispose()` na DAG
- **Arquivo**: `src/data_platform/dags/generate_video_thumbnails.py`
- Engine envolvido em `try/finally` com `engine.dispose()` no `fetch_batch()`
- Garante cleanup mesmo quando `fetch_articles_needing_thumbnails` levanta excecao

### 3. Validacao de JPEG magic bytes
- **Arquivo**: `src/data_platform/workers/thumbnail_worker/extractor.py`
- Verifica `\xff\xd8` (JPEG SOI marker) no output do ffmpeg antes de retornar
- Rejeita output corrompido, GIF, PNG ou bytes aleatorios com `ThumbnailExtractionError`

### 4. Sanitizacao de URLs nos logs
- **Arquivo**: `src/data_platform/workers/thumbnail_worker/extractor.py`
- Nova funcao `_sanitize_url()` remove query params e fragments via `urllib.parse`
- Aplicada em todas as 6 ocorrencias de URL em logs e mensagens de erro
- **Importante**: A URL completa (com query params) continua sendo passada ao ffmpeg — apenas a representacao em logs e sanitizada

### 5. Indice parcial para batch query
- **Arquivo novo**: `scripts/migrations/007_create_idx_news_video_no_image.sql`
- `CREATE INDEX idx_news_video_no_image ON news (published_at DESC, unique_id ASC) WHERE ...`
- Cobre exatamente o `WHERE` e `ORDER BY` da query de `batch.py`
- Rollback incluido: `007_create_idx_news_video_no_image_rollback.sql`

### 6. Paralelizacao do processamento na DAG
- **Arquivo**: `src/data_platform/dags/generate_video_thumbnails.py`
- Loop sequencial substituido por `concurrent.futures.ThreadPoolExecutor`
- `_process_one()` extraido como funcao top-level testavel
- `max_workers` configuravel via Airflow Variable `thumbnail_max_workers` (default: 5)
- Performance: worst case 20 min (antes: 100 min) para 100 artigos, dentro do `execution_timeout` de 30 min
- Compativel com infra: Cloud Run suporta 10 requests simultaneos (2 instancias * max_concurrency 5)

### 7. Ordem deterministica no batch query
- **Arquivo**: `src/data_platform/jobs/thumbnail/batch.py`
- Adicionado `n.unique_id ASC` como tiebreaker no `ORDER BY`
- Garante que artigos com mesmo `published_at` sejam processados na mesma ordem entre execucoes

## Impacto

- **Pipeline de dados**: Nenhuma mudanca no fluxo de dados. Mesmos inputs, mesmos outputs.
- **PostgreSQL**: Nova migration 007 (indice parcial). Nenhuma mudanca de schema.
- **Cloud Run**: Lifespan garante cleanup de conexoes. Sem mudancas de infra (Terraform).
- **Airflow**: Nova Variable `thumbnail_max_workers` (opcional, default 5). Demais Variables inalteradas.
- **Quebra**: Baixo risco. Todas as mudancas sao defensivas e retrocompativeis.

## Testes

- **65 testes** passando (antes: 50, sendo 1 quebrado)
- **15 novos testes** cobrindo todos os 7 itens
- **1 teste corrigido** (`test_query_excludes_previously_failed` — quebrado desde PR #124 por incompatibilidade com `sqlalchemy.text()`)
- **5 testes refatorados** (adaptados para lifespan em vez de `_get_pg`)
- `ruff check` e `black --check` limpos

### Novos testes por item

| Item | Testes | Arquivo |
|------|--------|---------|
| Lifespan (#1) | `test_lifespan_closes_pg_on_shutdown` | `test_thumbnail_app.py` |
| engine.dispose (#2) | `test_engine_dispose_in_finally_block` | `test_dag_thumbnail.py` |
| JPEG magic bytes (#3) | `test_non_jpeg_output_raises_extraction_error`, `test_random_bytes_output_raises_extraction_error` | `test_thumbnail_extractor.py` |
| URL sanitization (#4) | `TestSanitizeUrl` (4 testes), `test_error_message_does_not_leak_query_params` | `test_thumbnail_extractor.py` |
| Migration (#5) | Validacao via `migrate.py validate` | — |
| Paralelizacao (#6) | `test_uses_thread_pool_executor`, `test_has_process_one_function`, `TestProcessOne` (3 testes) | `test_dag_thumbnail.py` |
| ORDER BY (#7) | `test_query_has_deterministic_order` | `test_thumbnail_batch.py` |

## Test plan

- [ ] `poetry run pytest tests/unit/ -v -p no:postgresql` — todos os 65 testes passam
- [ ] `poetry run ruff check src/ tests/` — sem erros
- [ ] `poetry run black --check src/ tests/` — sem erros
- [ ] Validar migration: `python scripts/migrate.py validate`
- [ ] Apos deploy: verificar que DAG `generate_video_thumbnails` executa sem erros no Composer
- [ ] Apos deploy: verificar nos logs do Cloud Run que `close_all` e chamado no shutdown
- [ ] Apos deploy: verificar que URLs nos logs nao contem query params

## Notas para revisores

- **Item 4 (sanitize URLs)**: A funcao `_sanitize_url()` preserva o path completo. Se URLs com tokens no path forem uma preocupacao futura, o path pode ser truncado — mas esta fora do escopo desta issue.
- **Item 5 (migration)**: `CREATE INDEX` sem `CONCURRENTLY` bloqueia writes na tabela `news` brevemente (~300k linhas, poucos segundos). Executar em horario de baixo trafego.
- **Item 6 (paralelizacao)**: Default conservador de 5 workers. Pode ser ajustado via Airflow Variable `thumbnail_max_workers` sem redeploy.
- **Testes de DAG**: Airflow nao esta instalado localmente, entao os testes usam AST parsing para verificacao estrutural e `exec()` isolado para testar `_process_one`.