### PR TITLE
fix: migration 004 idempotente (CREATE OR REPLACE TRIGGER)

### DIFF
--- a/scripts/migrations/004_create_news_features.sql
+++ b/scripts/migrations/004_create_news_features.sql
@@ -23,7 +23,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_news_features_updated_at
+CREATE OR REPLACE TRIGGER trg_news_features_updated_at
     BEFORE UPDATE ON news_features
     FOR EACH ROW
     EXECUTE FUNCTION update_news_features_updated_at();


### PR DESCRIPTION
## Problema

O workflow `db-migrate` falha com `DuplicateObject` ao tentar aplicar a migração 008.

A causa raiz: a tabela `migration_history` está vazia — as migrações 001-007 foram aplicadas pelo workflow antigo e nunca registradas. O novo runner (`migrate.py`) as considera pendentes e tenta re-executá-las em dry-run.

A migração 004 cria um trigger com `CREATE TRIGGER` (sem `CREATE OR REPLACE`). Como o trigger já existe, o dry-run falha com:
```
DuplicateObject: trigger "trg_news_features_updated_at" for relation "news_features" already exists
```

## Solução

Trocar `CREATE TRIGGER` por `CREATE OR REPLACE TRIGGER` (disponível no PostgreSQL 14+; o projeto usa PG 15).

Todas as outras instruções em 004 já são idempotentes (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`).

## Impacto

- No banco de produção: nenhum — o trigger já existe, a instrução é no-op.
- Desbloqueia o dry-run e permite aplicar a migração 008 (`scrape_runs`).