### PR TITLE
feat: comando stamp para bootstrap do migration_history

### DIFF
--- a/.github/workflows/db-migrate.yaml
+++ b/.github/workflows/db-migrate.yaml
@@ -13,13 +13,14 @@ on:
           - rollback
           - history
           - validate
+          - stamp
       dry_run:
         description: 'Preview changes without applying (default: true)'
         required: false
         type: boolean
         default: true
       target_version:
-        description: 'Target version for migrate (--target) or rollback (VERSION)'
+        description: 'Target version for migrate (--target), rollback (VERSION), or stamp (VERSION)'
         required: false
         type: string
       confirm:
@@ -73,6 +74,17 @@ jobs:
           if [[ "$COMMAND" == "rollback" && -z "${{ inputs.target_version }}" ]]; then
             echo "::error::rollback requires target_version"
             exit 1
+          fi
+
+          if [[ "$COMMAND" == "stamp" ]]; then
+            if [[ -z "${{ inputs.target_version }}" ]]; then
+              echo "::error::stamp requires target_version"
+              exit 1
+            fi
+            if [[ "$CONFIRM" != "true" ]]; then
+              echo "::error::stamp requires confirm=true"
+              exit 1
+            fi
           fi
 
   backup:
@@ -209,6 +221,9 @@ jobs:
               if [ "$DRY_RUN" = "true" ]; then
                 ARGS+=(--dry-run)
               fi
+              ;;
+            stamp)
+              ARGS+=("stamp" "$TARGET" --db-url "$LOCAL_URL" --yes)
               ;;
           esac
 

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -591,6 +591,56 @@ def main():
         else:
             typer.echo(f"All {len(migrations)} migrations are consistent.")
 
+    @app.command()
+    def stamp(
+        version: str = typer.Argument(
+            ...,
+            help="Mark all pending migrations up to VERSION as applied without executing them (e.g. '007')",
+        ),
+        db_url: str = typer.Option(None, "--db-url", envvar="DATABASE_URL"),
+        migrations_path: str = typer.Option(str(MIGRATIONS_DIR), "--migrations-dir"),
+        yes: bool = typer.Option(False, "--yes", "-y"),
+    ):
+        """Bootstrap: mark migrations as applied without executing them.
+
+        Use when migrations were applied outside of this runner (e.g. via old workflow).
+        Only pending migrations are stamped; already-recorded ones are skipped.
+        """
+        conn = _connect(db_url)
+        try:
+            bootstrap(conn)
+            migrations = discover_migrations(Path(migrations_path))
+            pending = get_pending(conn, migrations, target=version)
+
+            if not pending:
+                typer.echo(f"No pending migrations up to {version}. Nothing to stamp.")
+                return
+
+            typer.echo(f"Will stamp {len(pending)} migration(s) as applied (no SQL executed):")
+            for m in pending:
+                typer.echo(f"  {m.version}_{m.name} ({m.migration_type})")
+
+            if not yes:
+                typer.confirm(
+                    "Stamp these migrations as applied without running them?", abort=True
+                )
+
+            applied_by = _get_applied_by()
+            run_id = _get_run_id()
+
+            for m in pending:
+                _record_history(
+                    conn, m, "migrate", "success", time.time(),
+                    applied_by, run_id,
+                    description="Stamped as applied — existing database bootstrap",
+                )
+                conn.commit()
+                typer.echo(f"  Stamped: {m.version}_{m.name}")
+
+            typer.echo(f"\nDone: {len(pending)} migration(s) stamped.")
+        finally:
+            conn.close()
+
     app()
 
 


### PR DESCRIPTION
## Problema

As migrations 001-007 foram aplicadas pelo workflow antigo (sem `migrate.py`) e nunca registradas em `migration_history`. O novo runner considera todas como pendentes e tenta re-executá-las.

Isso falha porque as migrations não são idempotentes para os dados atuais:
- **004**: trigger sem `CREATE OR REPLACE` (corrigido no PR #130)
- **005**: `UPDATE news SET legacy_unique_id = unique_id WHERE legacy_unique_id IS NULL` falha com `StringDataRightTruncation` — artigos adicionados após a migração 006 têm `legacy_unique_id = NULL` mas `unique_id` já no formato slug (até 107 chars, não cabe em VARCHAR(32))

Re-escrever as migrations para serem idempotentes com os dados atuais seria arriscado. A solução correta é um bootstrap.

## Solução

Novo comando `stamp` (equivalente ao `alembic stamp`):
- Marca migrations como aplicadas em `migration_history` **sem executar nenhum SQL**
- Só processa migrations pendentes; migrations já registradas são ignoradas
- Requer `confirm=true` no workflow (operação irreversível no sentido de que não há rollback automático)

## Uso

```bash
# Bootstrap: marcar 001-007 como aplicadas (já existem no banco)
poetry run python scripts/migrate.py stamp 007 --db-url $DATABASE_URL --yes
```

**Workflow GitHub Actions:**
```
command: stamp
target_version: 007
confirm: true
```

## Plano de execução após merge

1. Rodar `stamp 007` via workflow → marca 001-007 como aplicadas
2. Rodar dry-run de `migrate` → deve mostrar apenas 008 como pendente
3. Rodar `migrate` com `dry_run=false, confirm=true` → aplica 008 (cria `scrape_runs`)