### PR TITLE
fix(engagement): filtrar unique_ids orfaos antes do upsert em news_features

### DIFF
--- a/src/data_platform/jobs/bigquery/engagement.py
+++ b/src/data_platform/jobs/bigquery/engagement.py
@@ -1,7 +1,11 @@
 """Aggregate pageview engagement metrics from BigQuery."""
 
+import json
 import logging
+
 import pandas as pd
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
 
 logger = logging.getLogger(__name__)
 
@@ -48,11 +52,6 @@ def batch_upsert_engagement(db_url: str, metrics_df: pd.DataFrame) -> int:
     Returns:
         Number of rows updated
     """
-    import json
-
-    from sqlalchemy import create_engine, text
-    from sqlalchemy.pool import NullPool
-
     engine = create_engine(db_url, poolclass=NullPool)
     upsert_sql = text("""
         INSERT INTO news_features (unique_id, features)
@@ -64,6 +63,20 @@ def batch_upsert_engagement(db_url: str, metrics_df: pd.DataFrame) -> int:
     count = 0
     try:
         with engine.begin() as conn:
+            all_ids = metrics_df["unique_id"].tolist()
+            if all_ids:
+                valid_result = conn.execute(
+                    text("SELECT unique_id FROM news WHERE unique_id = ANY(:ids)"),
+                    {"ids": all_ids},
+                )
+                valid_ids = set(valid_result.scalars().all())
+                initial_count = len(metrics_df)
+                metrics_df = metrics_df[metrics_df["unique_id"].isin(valid_ids)]
+                orphaned = initial_count - len(metrics_df)
+                if orphaned:
+                    logger.warning(
+                        f"Filtered {orphaned} orphaned unique_ids not found in news table"
+                    )
             for _, row in metrics_df.iterrows():
                 features = json.dumps({
                     "view_count": int(row["view_count"]),

--- a/tests/unit/test_engagement.py
+++ b/tests/unit/test_engagement.py
@@ -92,8 +92,11 @@ class TestBatchUpsertEngagement:
         })
         batch_upsert_engagement("postgresql://test", df)
 
-        call = mock_conn.execute.call_args_list[1]
-        params = call.args[1]
+        upsert_call = next(
+            c for c in mock_conn.execute.call_args_list
+            if "INSERT INTO" in str(c.args[0])
+        )
+        params = upsert_call.args[1]
         assert params["uid"] == "art-1"
         assert json.loads(params["features"]) == {"view_count": 42, "unique_sessions": 30}
 
@@ -150,20 +153,20 @@ class TestBatchUpsertEngagement:
         assert count == 1
         mock_engine.dispose.assert_called_once()
 
-    def test_logs_orphaned_count(self, caplog):
-        with patch("data_platform.jobs.bigquery.engagement.create_engine") as mock_create_engine:
-            mock_engine = MagicMock()
-            mock_conn = MagicMock()
-            mock_create_engine.return_value = mock_engine
-            mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
-            mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
-            mock_conn.execute.return_value.scalars.return_value.all.return_value = ["art-1"]
+    @patch("data_platform.jobs.bigquery.engagement.create_engine")
+    def test_logs_orphaned_count(self, mock_create_engine, caplog):
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.scalars.return_value.all.return_value = ["art-1"]
 
-            df = pd.DataFrame({
-                "unique_id": ["art-1", "orphan-1", "orphan-2"],
-                "view_count": [100, 50, 30],
-                "unique_sessions": [80, 40, 25],
-            })
-            with caplog.at_level(logging.WARNING, logger="data_platform.jobs.bigquery.engagement"):
-                batch_upsert_engagement("postgresql://test", df)
-            assert "Filtered 2 orphaned" in caplog.text
+        df = pd.DataFrame({
+            "unique_id": ["art-1", "orphan-1", "orphan-2"],
+            "view_count": [100, 50, 30],
+            "unique_sessions": [80, 40, 25],
+        })
+        with caplog.at_level(logging.WARNING, logger="data_platform.jobs.bigquery.engagement"):
+            batch_upsert_engagement("postgresql://test", df)
+        assert "Filtered 2 orphaned" in caplog.text

--- a/tests/unit/test_engagement.py
+++ b/tests/unit/test_engagement.py
@@ -1,6 +1,9 @@
 """Unit tests for engagement metrics aggregation."""
 
+import json
+import logging
 from unittest.mock import MagicMock, patch
+
 import pandas as pd
 import pytest
 
@@ -55,10 +58,14 @@ class TestEngagementQuery:
 
 class TestBatchUpsertEngagement:
 
-    @patch("data_platform.managers.postgres_manager.PostgresManager")
-    def test_upserts_all_rows(self, mock_pg_class):
-        mock_pg = mock_pg_class.return_value
-        mock_pg.upsert_features.return_value = True
+    @patch("data_platform.jobs.bigquery.engagement.create_engine")
+    def test_upserts_all_rows(self, mock_create_engine):
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.scalars.return_value.all.return_value = ["art-1", "art-2"]
 
         df = pd.DataFrame({
             "unique_id": ["art-1", "art-2"],
@@ -67,12 +74,16 @@ class TestBatchUpsertEngagement:
         })
         count = batch_upsert_engagement("postgresql://test", df)
         assert count == 2
-        mock_pg.close_all.assert_called_once()
+        mock_engine.dispose.assert_called_once()
 
-    @patch("data_platform.managers.postgres_manager.PostgresManager")
-    def test_upserts_correct_features(self, mock_pg_class):
-        mock_pg = mock_pg_class.return_value
-        mock_pg.upsert_features.return_value = True
+    @patch("data_platform.jobs.bigquery.engagement.create_engine")
+    def test_upserts_correct_features(self, mock_create_engine):
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.scalars.return_value.all.return_value = ["art-1"]
 
         df = pd.DataFrame({
             "unique_id": ["art-1"],
@@ -81,22 +92,36 @@ class TestBatchUpsertEngagement:
         })
         batch_upsert_engagement("postgresql://test", df)
 
-        mock_pg.upsert_features.assert_called_once_with(
-            "art-1", {"view_count": 42, "unique_sessions": 30}
-        )
+        call = mock_conn.execute.call_args_list[1]
+        params = call.args[1]
+        assert params["uid"] == "art-1"
+        assert json.loads(params["features"]) == {"view_count": 42, "unique_sessions": 30}
 
-    @patch("data_platform.managers.postgres_manager.PostgresManager")
-    def test_empty_dataframe(self, mock_pg_class):
-        mock_pg = mock_pg_class.return_value
+    @patch("data_platform.jobs.bigquery.engagement.create_engine")
+    def test_empty_dataframe(self, mock_create_engine):
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
         df = pd.DataFrame(columns=["unique_id", "view_count", "unique_sessions"])
         count = batch_upsert_engagement("postgresql://test", df)
         assert count == 0
-        mock_pg.close_all.assert_called_once()
+        mock_conn.execute.assert_not_called()
+        mock_engine.dispose.assert_called_once()
 
-    @patch("data_platform.managers.postgres_manager.PostgresManager")
-    def test_closes_pg_on_error(self, mock_pg_class):
-        mock_pg = mock_pg_class.return_value
-        mock_pg.upsert_features.side_effect = Exception("DB error")
+    @patch("data_platform.jobs.bigquery.engagement.create_engine")
+    def test_disposes_engine_on_error(self, mock_create_engine):
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+        filter_result = MagicMock()
+        filter_result.scalars.return_value.all.return_value = ["art-1"]
+        mock_conn.execute.side_effect = [filter_result, Exception("DB error")]
 
         df = pd.DataFrame({
             "unique_id": ["art-1"],
@@ -105,5 +130,40 @@ class TestBatchUpsertEngagement:
         })
         with pytest.raises(Exception, match="DB error"):
             batch_upsert_engagement("postgresql://test", df)
+        mock_engine.dispose.assert_called_once()
 
-        mock_pg.close_all.assert_called_once()
+    @patch("data_platform.jobs.bigquery.engagement.create_engine")
+    def test_filters_orphaned_ids(self, mock_create_engine):
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_create_engine.return_value = mock_engine
+        mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.scalars.return_value.all.return_value = ["art-1"]
+
+        df = pd.DataFrame({
+            "unique_id": ["art-1", "orphan-1"],
+            "view_count": [100, 50],
+            "unique_sessions": [80, 40],
+        })
+        count = batch_upsert_engagement("postgresql://test", df)
+        assert count == 1
+        mock_engine.dispose.assert_called_once()
+
+    def test_logs_orphaned_count(self, caplog):
+        with patch("data_platform.jobs.bigquery.engagement.create_engine") as mock_create_engine:
+            mock_engine = MagicMock()
+            mock_conn = MagicMock()
+            mock_create_engine.return_value = mock_engine
+            mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+            mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+            mock_conn.execute.return_value.scalars.return_value.all.return_value = ["art-1"]
+
+            df = pd.DataFrame({
+                "unique_id": ["art-1", "orphan-1", "orphan-2"],
+                "view_count": [100, 50, 30],
+                "unique_sessions": [80, 40, 25],
+            })
+            with caplog.at_level(logging.WARNING, logger="data_platform.jobs.bigquery.engagement"):
+                batch_upsert_engagement("postgresql://test", df)
+            assert "Filtered 2 orphaned" in caplog.text


### PR DESCRIPTION
## Problema

A DAG `aggregate_engagement` falha diariamente com `ForeignKeyViolation` desde 2026-03-23.

`batch_upsert_engagement` executa `INSERT INTO news_features` para cada `unique_id` extraído do BigQuery (`umami_pageviews`). Alguns desses IDs referenciam artigos que não existem em `news`, violando a FK constraint — o que aborta a transação inteira e impede a atualização de engagement de **todos** os artigos.

Closes #121

## Causa raiz

URLs no BigQuery podem conter IDs de artigos que nunca foram inseridos no PostgreSQL (crawlers, URLs fabricadas, IDs pré-migração). A função não validava a existência dos IDs antes do upsert.

## Solução

Adicionada pré-filtragem em `batch_upsert_engagement` via `SELECT unique_id FROM news WHERE unique_id = ANY(:ids)` antes do loop de upsert. IDs órfãos são descartados silenciosamente com `logger.warning` indicando o count filtrado.

**Fluxo anterior:**
```
BigQuery → DataFrame → INSERT (falha se ID não existe em news)
```

**Fluxo após o fix:**
```
BigQuery → DataFrame → SELECT ANY(:ids) → filtrar órfãos → INSERT (apenas IDs válidos)
```

A abordagem com `ANY(:ids)` foi escolhida sobre `try/except IntegrityError` (requer SAVEPOINT por row em PG) e LEFT JOIN no BigQuery (sem acesso ao PG).

## Mudanças

### `src/data_platform/jobs/bigquery/engagement.py`
- Importações de `create_engine`, `text`, `NullPool` e `json` movidas para nível de módulo (necessário para testabilidade via `mock.patch`)
- Adicionada pré-filtragem com `SELECT ANY(:ids)` dentro do mesmo `engine.begin()`, antes do loop
- `logger.warning` emitido com count exato de IDs órfãos quando `> 0`

### `tests/unit/test_engagement.py`
- 4 testes reescritos: substituído mock de `PostgresManager` (API legada) por mock de `create_engine` (SQLAlchemy direto)
- `test_closes_pg_on_error` → renomeado para `test_disposes_engine_on_error`
- 2 testes novos: `test_filters_orphaned_ids` e `test_logs_orphaned_count`

## Testes

```
pytest tests/unit/test_engagement.py -v
```

```
TestEngagementQuery          9/9 PASSED
TestBatchUpsertEngagement    6/6 PASSED  (4 reescritos + 2 novos)
```

## Fora do escopo

`trending.py` tem a mesma vulnerabilidade mas será tratado em issue separada.

## Checklist

- [x] Testes unitários cobrindo happy path, filtragem, logging, payload, edge case vazio e cleanup em erro
- [x] `engine.dispose()` chamado em todos os cenários (sucesso e erro)
- [x] Sem alterações em schema, migrations, DAGs ou outros módulos
- [x] Suite completa `pytest tests/unit/` sem regressões novas