### PR TITLE
fix: popular migration_history retroativamente e auditar idempotencia (#131)

### DIFF
--- a/scripts/migrations/005_alter_unique_id_varchar.sql
+++ b/scripts/migrations/005_alter_unique_id_varchar.sql
@@ -10,6 +10,8 @@ BEGIN;
 ALTER TABLE news ADD COLUMN IF NOT EXISTS legacy_unique_id VARCHAR(32);
 
 -- Step 2: Backfill legacy column with current MD5 IDs
+-- IMPORTANT: Must run BEFORE migration 006 (which converts unique_id to slugs)
+-- Re-execution is safe: WHERE IS NULL filters out already-populated rows
 UPDATE news SET legacy_unique_id = unique_id WHERE legacy_unique_id IS NULL;
 
 -- Step 3: Widen unique_id on news table (only if still narrower than 120)

--- a/scripts/migrations/005_alter_unique_id_varchar.sql
+++ b/scripts/migrations/005_alter_unique_id_varchar.sql
@@ -12,17 +12,32 @@ ALTER TABLE news ADD COLUMN IF NOT EXISTS legacy_unique_id VARCHAR(32);
 -- Step 2: Backfill legacy column with current MD5 IDs
 UPDATE news SET legacy_unique_id = unique_id WHERE legacy_unique_id IS NULL;
 
--- Step 3: Drop view that depends on news.unique_id (will be recreated in step 6)
-DROP VIEW IF EXISTS news_with_themes;
+-- Step 3: Widen unique_id on news table (only if still narrower than 120)
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'news'
+      AND column_name = 'unique_id'
+      AND character_maximum_length < 120
+  ) THEN
+    ALTER TABLE news ALTER COLUMN unique_id TYPE VARCHAR(120);
+  END IF;
+END $$;
 
--- Step 4: Widen unique_id on news table
-ALTER TABLE news ALTER COLUMN unique_id TYPE VARCHAR(120);
+-- Step 4: Widen unique_id on news_features table (only if still narrower than 120)
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'news_features'
+      AND column_name = 'unique_id'
+      AND character_maximum_length < 120
+  ) THEN
+    ALTER TABLE news_features ALTER COLUMN unique_id TYPE VARCHAR(120);
+  END IF;
+END $$;
 
--- Step 5: Widen unique_id on news_features table
-ALTER TABLE news_features ALTER COLUMN unique_id TYPE VARCHAR(120);
-
--- Step 6: Recreate the view
-CREATE VIEW news_with_themes AS
+-- Step 5: Recreate the view (idempotent with OR REPLACE)
+CREATE OR REPLACE VIEW news_with_themes AS
 SELECT
     n.id,
     n.unique_id,
@@ -40,10 +55,10 @@ LEFT JOIN themes t1 ON n.theme_l1_id = t1.id
 LEFT JOIN themes t2 ON n.theme_l2_id = t2.id
 LEFT JOIN themes t3 ON n.theme_l3_id = t3.id;
 
--- Step 7: Index on legacy_unique_id for redirect lookups
+-- Step 6: Index on legacy_unique_id for redirect lookups
 CREATE INDEX IF NOT EXISTS idx_news_legacy_unique_id ON news(legacy_unique_id);
 
--- Step 8: Update schema_version
+-- Step 7: Update schema_version
 INSERT INTO schema_version (version, description)
 VALUES ('1.3', 'Widen unique_id to VARCHAR(120) for readable slugs, add legacy_unique_id')
 ON CONFLICT (version) DO NOTHING;

--- a/tests/unit/test_migrate_runner.py
+++ b/tests/unit/test_migrate_runner.py
@@ -517,3 +517,106 @@ class TestValidateMigrations:
         migrations = discover_migrations(tmp_path)
         issues = validate_migrations(migrations)
         assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# Stamp
+# ---------------------------------------------------------------------------
+class TestStamp:
+    """Tests for the stamp CLI command (mark migrations as applied without executing)."""
+
+    def _make_migrations(self, versions):
+        """Create MigrationInfo list for given version strings."""
+        from migrate import MigrationInfo
+
+        return [
+            MigrationInfo(
+                version=v,
+                name=f"migration_{v}",
+                path=Path(f"{v}_migration_{v}.sql"),
+                migration_type="sql",
+                rollback_path=None,
+            )
+            for v in versions
+        ]
+
+    def _run_stamp(self, target, migrations_dir, pending, mock_conn):
+        """Run the stamp command via main() with mocked dependencies."""
+        import migrate
+
+        with patch.object(
+            sys, "argv",
+            ["migrate.py", "stamp", target, "--db-url", "postgresql://test", "--yes"],
+        ), patch("psycopg2.connect", return_value=mock_conn), patch.object(
+            migrate, "bootstrap"
+        ), patch.object(
+            migrate, "discover_migrations", return_value=self._make_migrations(
+                [m.version for m in pending]
+                + [v for v in ["001", "002", "003", "004", "005"] if v <= target]
+            ),
+        ) as mock_discover, patch.object(
+            migrate, "get_pending", return_value=pending
+        ) as mock_get_pending, patch.object(
+            migrate, "_record_history"
+        ) as mock_record, patch.object(
+            migrate, "_get_applied_by", return_value="test-user"
+        ), patch.object(
+            migrate, "_get_run_id", return_value=None
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                migrate.main()
+            assert exc_info.value.code in (None, 0)
+            return mock_record, mock_discover, mock_get_pending
+
+    def test_stamp_marks_pending_as_applied(self):
+        pending = self._make_migrations(["001", "002", "003"])
+        mock_conn = MagicMock()
+
+        mock_record, _, _ = self._run_stamp("003", "/tmp", pending, mock_conn)
+
+        assert mock_record.call_count == 3
+        for c in mock_record.call_args_list:
+            args, kwargs = c
+            # positional: conn, migration, "migrate", "success", started_at, applied_by, run_id
+            assert args[2] == "migrate"       # operation
+            assert args[3] == "success"       # status
+            assert "Stamped" in kwargs.get("description", "")
+
+    def test_stamp_skips_already_applied(self):
+        # Only 003 is pending (001, 002 already applied)
+        pending = self._make_migrations(["003"])
+        mock_conn = MagicMock()
+
+        mock_record, _, _ = self._run_stamp("003", "/tmp", pending, mock_conn)
+
+        assert mock_record.call_count == 1
+        args = mock_record.call_args_list[0][0]
+        assert args[1].version == "003"
+
+    def test_stamp_respects_target_version(self):
+        pending = self._make_migrations(["001", "002", "003"])
+        mock_conn = MagicMock()
+
+        mock_record, _, mock_get_pending = self._run_stamp("003", "/tmp", pending, mock_conn)
+
+        # get_pending should have been called with target="003"
+        gp_call = mock_get_pending.call_args
+        gp_positional = gp_call[0]
+        gp_kwargs = gp_call[1]
+        target_arg = gp_kwargs.get("target") or (gp_positional[2] if len(gp_positional) > 2 else None)
+        assert target_arg == "003"
+
+        # Only 001-003 stamped (as returned by mocked get_pending)
+        assert mock_record.call_count == 3
+        stamped_versions = [c[0][1].version for c in mock_record.call_args_list]
+        assert stamped_versions == ["001", "002", "003"]
+
+    def test_stamp_noop_when_all_applied(self, capsys):
+        pending = []  # nothing pending
+        mock_conn = MagicMock()
+
+        mock_record, _, _ = self._run_stamp("003", "/tmp", pending, mock_conn)
+
+        assert mock_record.call_count == 0
+        captured = capsys.readouterr()
+        assert "Nothing to stamp" in captured.out


### PR DESCRIPTION
## Contexto

O workflow `db-migrate` usa `scripts/migrate.py` para aplicar migracoes rastreadas via tabela `migration_history`. As migracoes 001-007 foram aplicadas por um runner antigo e **nunca foram registradas** na `migration_history`. O runner atual as considera pendentes e tenta re-executa-las, causando falhas espurias no workflow.

O PR #130 corrigiu o sintoma imediato (migracao 004), mas a causa raiz persiste: as migracoes 005-007 ainda podem falhar ou causar efeitos colaterais ao ser re-executadas.

## Solucao

### 1. Usar `stamp 007` para backfill (acao operacional pos-merge)
O `migrate.py` ja possui o comando `stamp` (adicionado em #130) que marca migracoes como aplicadas sem executa-las. Nao e necessario criar um script SQL one-shot.

### 2. Tornar migracao 005 idempotente (este PR)
- `ALTER COLUMN TYPE VARCHAR(120)` envolvido em guards condicionais (`DO $$ ... END $$`) que verificam `character_maximum_length < 120` antes de executar, evitando table rewrite desnecessario em ~300k rows
- `DROP VIEW IF EXISTS` + `CREATE VIEW` substituido por `CREATE OR REPLACE VIEW`

### 3. Adicionar testes para `stamp` (este PR)
4 testes unitarios cobrindo gap de cobertura do comando `stamp`.

## Justificativa tecnica

- **Por que nao um script SQL one-shot?** O comando `stamp` ja existe e faz exatamente isso. Criar um script seria redundante.
- **Por que guards condicionais em vez de IF NOT EXISTS?** PostgreSQL nao suporta `ALTER COLUMN IF NOT EXISTS TYPE`. O bloco `DO $$` com query na `information_schema` e a alternativa idiomatica.
- **Por que `CREATE OR REPLACE VIEW`?** Elimina a necessidade de `DROP VIEW IF EXISTS` antes, tornando a operacao atomica e idempotente.

## Detalhamento tecnico

### Arquivos modificados

| Arquivo | Mudanca |
|---------|---------|
| `scripts/migrations/005_alter_unique_id_varchar.sql` | Guards condicionais nos ALTER COLUMN TYPE + CREATE OR REPLACE VIEW |
| `tests/unit/test_migrate_runner.py` | Classe TestStamp com 4 testes unitarios |

### Impactos
- **Performance**: Nenhum. Os guards evitam table rewrite quando a coluna ja tem o tamanho correto.
- **Compatibilidade**: PostgreSQL 14+ (projeto usa PG 15). `CREATE OR REPLACE VIEW` disponivel desde PG 9.1+.
- **Dependencias**: Nenhuma nova.

## Testes

```
$ poetry run pytest tests/unit/test_migrate_runner.py -v -p no:postgresql
30 passed in 0.11s
```

- `test_stamp_marks_pending_as_applied` — verifica que stamp registra migracoes com operation=migrate, status=success
- `test_stamp_skips_already_applied` — verifica skip de migracoes ja registradas
- `test_stamp_respects_target_version` — verifica que `get_pending` recebe target correto
- `test_stamp_noop_when_all_applied` — verifica mensagem "Nothing to stamp" quando nada pendente

```
$ poetry run python scripts/migrate.py validate
All 8 migrations are consistent.
```

## Checklist

- [x] Codigo revisado
- [x] Testes realizados (30/30 passando, 0 regressoes)
- [x] Sem regressoes conhecidas
- [x] Segue padroes de codigo do projeto

## Pos-merge (acao operacional)

1. Executar via workflow: `db-migrate` com command=**stamp**, target_version=**007**, confirm=**true**
2. Verificar: `status` mostra 001-007 como APPLIED
3. Verificar: `migrate --dry-run` executa sem erros

Closes #131