### PR TITLE
feat: deduplicação de notícias por URL e content_hash (portal#108)

### DIFF
--- a/docs/database/schema.md
+++ b/docs/database/schema.md
@@ -108,6 +108,9 @@ CREATE TABLE news (
     updated_at              TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     synced_to_hf_at         TIMESTAMP WITH TIME ZONE,
 
+    -- Deduplication
+    content_hash            VARCHAR(16),    -- SHA-256 truncated (title+content normalized)
+
     -- Denormalized (performance)
     agency_key              VARCHAR(100),
     agency_name             VARCHAR(500)
@@ -120,6 +123,10 @@ CREATE TABLE news (
 - `idx_news_agency_id` on `agency_id`
 - `idx_news_most_specific_theme` on `most_specific_theme_id`
 
+**Deduplication indexes**:
+- `idx_news_agency_url_unique` (UNIQUE, partial) on `(agency_key, url) WHERE url IS NOT NULL`
+- `idx_news_content_hash` (partial) on `content_hash WHERE content_hash IS NOT NULL`
+
 **Performance indexes**:
 - `idx_news_agency_key` on `agency_key` (denormalized)
 - `idx_news_agency_date` on `(agency_id, published_at DESC)`
@@ -129,7 +136,8 @@ CREATE TABLE news (
 - `idx_news_fts` (GIN) on `to_tsvector('portuguese', title || ' ' || content)`
 
 **Key fields**:
-- `unique_id`: MD5(agency + published_at + title)
+- `unique_id`: slugify(title) + "_" + MD5(agency + published_at + title)[:6]
+- `content_hash`: SHA-256(normalize(title) + "\n" + normalize(content))[:16] for cross-agency dedup
 - `most_specific_theme_id`: Most granular theme (L3 > L2 > L1)
 - `synced_to_hf_at`: Last sync to HuggingFace Dataset
 - `agency_key`, `agency_name`: Denormalized from agencies for performance

--- a/scripts/migrations/009_add_content_hash_and_url_index.sql
+++ b/scripts/migrations/009_add_content_hash_and_url_index.sql
@@ -1,0 +1,35 @@
+-- 009_add_content_hash_and_url_index.sql
+-- Adiciona coluna content_hash para deduplicacao cross-agency e
+-- atualiza FK de news_features com ON UPDATE CASCADE.
+-- Ref: destaquesgovbr/portal#108, destaquesgovbr/data-platform#138
+
+BEGIN;
+
+-- Coluna content_hash (SHA-256 truncado 16 hex)
+ALTER TABLE news ADD COLUMN IF NOT EXISTS content_hash VARCHAR(16);
+
+-- Medida defensiva: adicionar ON UPDATE CASCADE a FK de news_features
+ALTER TABLE news_features DROP CONSTRAINT IF EXISTS news_features_unique_id_fkey;
+ALTER TABLE news_features ADD CONSTRAINT news_features_unique_id_fkey
+    FOREIGN KEY (unique_id) REFERENCES news(unique_id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Indice para agrupamento por content_hash (nao-unique)
+CREATE INDEX IF NOT EXISTS idx_news_content_hash ON news(content_hash) WHERE content_hash IS NOT NULL;
+
+-- View news_with_themes depende de news.* e precisa ser recriada
+DROP VIEW IF EXISTS news_with_themes;
+CREATE VIEW news_with_themes AS
+SELECT
+    n.id, n.unique_id, n.title, n.url, n.agency_name, n.published_at, n.summary,
+    t1.label as theme_l1, t2.label as theme_l2, t3.label as theme_l3,
+    COALESCE(t3.label, t2.label, t1.label) as most_specific_theme
+FROM news n
+LEFT JOIN themes t1 ON n.theme_l1_id = t1.id
+LEFT JOIN themes t2 ON n.theme_l2_id = t2.id
+LEFT JOIN themes t3 ON n.theme_l3_id = t3.id;
+
+INSERT INTO schema_version (version, description)
+VALUES ('1.5', 'Add content_hash column, update news_features FK with ON UPDATE CASCADE')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/scripts/migrations/009_add_content_hash_and_url_index.sql
+++ b/scripts/migrations/009_add_content_hash_and_url_index.sql
@@ -16,18 +16,6 @@ ALTER TABLE news_features ADD CONSTRAINT news_features_unique_id_fkey
 -- Indice para agrupamento por content_hash (nao-unique)
 CREATE INDEX IF NOT EXISTS idx_news_content_hash ON news(content_hash) WHERE content_hash IS NOT NULL;
 
--- View news_with_themes depende de news.* e precisa ser recriada
-DROP VIEW IF EXISTS news_with_themes;
-CREATE VIEW news_with_themes AS
-SELECT
-    n.id, n.unique_id, n.title, n.url, n.agency_name, n.published_at, n.summary,
-    t1.label as theme_l1, t2.label as theme_l2, t3.label as theme_l3,
-    COALESCE(t3.label, t2.label, t1.label) as most_specific_theme
-FROM news n
-LEFT JOIN themes t1 ON n.theme_l1_id = t1.id
-LEFT JOIN themes t2 ON n.theme_l2_id = t2.id
-LEFT JOIN themes t3 ON n.theme_l3_id = t3.id;
-
 INSERT INTO schema_version (version, description)
 VALUES ('1.5', 'Add content_hash column, update news_features FK with ON UPDATE CASCADE')
 ON CONFLICT (version) DO NOTHING;

--- a/scripts/migrations/009_add_content_hash_and_url_index_rollback.sql
+++ b/scripts/migrations/009_add_content_hash_and_url_index_rollback.sql
@@ -1,0 +1,28 @@
+-- Rollback for 009_add_content_hash_and_url_index.sql
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_news_content_hash;
+
+ALTER TABLE news DROP COLUMN IF EXISTS content_hash;
+
+-- Restaurar FK original (sem ON UPDATE CASCADE)
+ALTER TABLE news_features DROP CONSTRAINT IF EXISTS news_features_unique_id_fkey;
+ALTER TABLE news_features ADD CONSTRAINT news_features_unique_id_fkey
+    FOREIGN KEY (unique_id) REFERENCES news(unique_id) ON DELETE CASCADE;
+
+-- Recriar view (sem content_hash a coluna ja nao existe)
+DROP VIEW IF EXISTS news_with_themes;
+CREATE VIEW news_with_themes AS
+SELECT
+    n.id, n.unique_id, n.title, n.url, n.agency_name, n.published_at, n.summary,
+    t1.label as theme_l1, t2.label as theme_l2, t3.label as theme_l3,
+    COALESCE(t3.label, t2.label, t1.label) as most_specific_theme
+FROM news n
+LEFT JOIN themes t1 ON n.theme_l1_id = t1.id
+LEFT JOIN themes t2 ON n.theme_l2_id = t2.id
+LEFT JOIN themes t3 ON n.theme_l3_id = t3.id;
+
+DELETE FROM schema_version WHERE version = '1.5';
+
+COMMIT;

--- a/scripts/migrations/010_backfill_content_hash.py
+++ b/scripts/migrations/010_backfill_content_hash.py
@@ -1,0 +1,102 @@
+"""
+Backfill content_hash for all existing news records.
+
+Computes SHA-256(normalize(title) + "\\n" + normalize(content))[:16] for each row.
+Runs in batches of 5000 to avoid long-running transactions. Idempotent.
+
+Ref: destaquesgovbr/portal#108, destaquesgovbr/data-platform#138
+"""
+
+import hashlib
+import re
+import time
+import unicodedata
+
+
+BATCH_SIZE = 5000
+
+
+def normalize_text(text: str | None) -> str:
+    if not text:
+        return ""
+    text = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    text = text.lower()
+    text = re.sub(r"[^\w\s]", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def compute_content_hash(title: str, content: str | None) -> str:
+    normalized = normalize_text(title) + "\n" + normalize_text(content)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def describe() -> str:
+    return "Backfill content_hash para registros existentes na tabela news"
+
+
+def migrate(conn, dry_run: bool = False) -> dict:
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT COUNT(*) FROM news WHERE content_hash IS NULL")
+    total_pending = cursor.fetchone()[0]
+
+    if total_pending == 0:
+        cursor.close()
+        return {"rows_updated": 0, "message": "All rows already have content_hash"}
+
+    if dry_run:
+        cursor.close()
+        return {"rows_updated": 0, "to_update": total_pending, "preview": True}
+
+    t0 = time.time()
+    total_updated = 0
+
+    while True:
+        cursor.execute(
+            "SELECT id, title, content FROM news WHERE content_hash IS NULL LIMIT %s",
+            (BATCH_SIZE,),
+        )
+        rows = cursor.fetchall()
+        if not rows:
+            break
+
+        from psycopg2.extras import execute_batch
+
+        params = []
+        for row_id, title, content in rows:
+            ch = compute_content_hash(title or "", content)
+            params.append((ch, row_id))
+
+        execute_batch(
+            cursor,
+            "UPDATE news SET content_hash = %s WHERE id = %s",
+            params,
+            page_size=1000,
+        )
+        total_updated += len(params)
+
+    cursor.close()
+    elapsed = time.time() - t0
+
+    return {
+        "rows_updated": total_updated,
+        "elapsed_seconds": round(elapsed, 2),
+    }
+
+
+def rollback(conn, dry_run: bool = False) -> dict:
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT COUNT(*) FROM news WHERE content_hash IS NOT NULL")
+    to_clear = cursor.fetchone()[0]
+
+    if dry_run:
+        cursor.close()
+        return {"rows_cleared": 0, "to_clear": to_clear, "preview": True}
+
+    cursor.execute("UPDATE news SET content_hash = NULL")
+    cleared = cursor.rowcount
+    cursor.close()
+
+    return {"rows_cleared": cleared}

--- a/scripts/migrations/010_backfill_content_hash.py
+++ b/scripts/migrations/010_backfill_content_hash.py
@@ -16,6 +16,8 @@ import unicodedata
 BATCH_SIZE = 5000
 
 
+# Canonical implementation: scraper/src/govbr_scraper/scrapers/content_hash.py
+# Inlined here to avoid cross-repo dependency at migration time.
 def normalize_text(text: str | None) -> str:
     if not text:
         return ""
@@ -75,6 +77,7 @@ def migrate(conn, dry_run: bool = False) -> dict:
             page_size=1000,
         )
         total_updated += len(params)
+        conn.commit()
 
     cursor.close()
     elapsed = time.time() - t0

--- a/scripts/migrations/010_backfill_content_hash.py
+++ b/scripts/migrations/010_backfill_content_hash.py
@@ -28,8 +28,12 @@ def normalize_text(text: str | None) -> str:
     return text
 
 
-def compute_content_hash(title: str, content: str | None) -> str:
-    normalized = normalize_text(title) + "\n" + normalize_text(content)
+def compute_content_hash(title: str, content: str | None) -> str | None:
+    norm_title = normalize_text(title)
+    norm_content = normalize_text(content)
+    if not norm_title and not norm_content:
+        return None
+    normalized = norm_title + "\n" + norm_content
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
 
 

--- a/scripts/migrations/010_backfill_content_hash.py
+++ b/scripts/migrations/010_backfill_content_hash.py
@@ -8,7 +8,9 @@ Ref: destaquesgovbr/portal#108, destaquesgovbr/data-platform#138
 """
 
 import hashlib
+import os
 import re
+import sys
 import time
 import unicodedata
 
@@ -107,3 +109,34 @@ def rollback(conn, dry_run: bool = False) -> dict:
     cursor.close()
 
     return {"rows_cleared": cleared}
+
+
+if __name__ == "__main__":
+    import argparse
+
+    import psycopg2
+
+    parser = argparse.ArgumentParser(description=describe())
+    parser.add_argument("--dry-run", action="store_true", help="Preview without updating")
+    parser.add_argument("--confirm", action="store_true", help="Execute backfill")
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.confirm:
+        print("Must specify --dry-run or --confirm")
+        sys.exit(1)
+
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        print("DATABASE_URL not set")
+        sys.exit(1)
+
+    conn = psycopg2.connect(database_url)
+    try:
+        result = migrate(conn, dry_run=args.dry_run)
+        print(result)
+    except Exception as e:
+        conn.rollback()
+        print(f"Error: {e}")
+        sys.exit(1)
+    finally:
+        conn.close()

--- a/scripts/migrations/011_cleanup_url_duplicates.py
+++ b/scripts/migrations/011_cleanup_url_duplicates.py
@@ -17,6 +17,7 @@ Ref: destaquesgovbr/portal#108, destaquesgovbr/data-platform#138
 """
 
 import argparse
+import logging
 import os
 import sys
 import time
@@ -56,12 +57,7 @@ def _find_duplicate_groups(conn):
 def _delete_batch(conn, unique_ids_to_delete):
     cursor = conn.cursor()
 
-    cursor.execute(
-        "DELETE FROM news_features WHERE unique_id = ANY(%s)",
-        (unique_ids_to_delete,),
-    )
-    features_deleted = cursor.rowcount
-
+    # news_features rows are cascade-deleted via FK ON DELETE CASCADE
     cursor.execute(
         "DELETE FROM news WHERE unique_id = ANY(%s)",
         (unique_ids_to_delete,),
@@ -69,7 +65,7 @@ def _delete_batch(conn, unique_ids_to_delete):
     news_deleted = cursor.rowcount
 
     cursor.close()
-    return news_deleted, features_deleted
+    return news_deleted
 
 
 def _try_delete_from_typesense(unique_ids):
@@ -91,8 +87,12 @@ def _try_delete_from_typesense(unique_ids):
             )
             if resp.status_code in (200, 404):
                 deleted += 1
-    except Exception:
-        pass
+    except Exception as e:
+        logging.warning(f"Typesense cleanup error: {e}")
+    if deleted < len(unique_ids):
+        logging.warning(
+            f"Typesense cleanup partial: {deleted}/{len(unique_ids)} documents deleted"
+        )
     return deleted
 
 
@@ -124,13 +124,11 @@ def migrate(conn, dry_run: bool = False, batch_size: int = BATCH_SIZE) -> dict:
 
     t0 = time.time()
     total_news_deleted = 0
-    total_features_deleted = 0
 
     for i in range(0, len(all_to_delete), batch_size):
         batch = all_to_delete[i : i + batch_size]
-        news_del, feat_del = _delete_batch(conn, batch)
+        news_del = _delete_batch(conn, batch)
         total_news_deleted += news_del
-        total_features_deleted += feat_del
 
     typesense_deleted = _try_delete_from_typesense(all_to_delete)
 
@@ -139,7 +137,6 @@ def migrate(conn, dry_run: bool = False, batch_size: int = BATCH_SIZE) -> dict:
     return {
         "groups": len(groups),
         "news_deleted": total_news_deleted,
-        "features_deleted": total_features_deleted,
         "typesense_deleted": typesense_deleted,
         "preserved_with_embedding": preserved_with_embedding,
         "elapsed_seconds": round(elapsed, 2),

--- a/scripts/migrations/011_cleanup_url_duplicates.py
+++ b/scripts/migrations/011_cleanup_url_duplicates.py
@@ -1,0 +1,185 @@
+"""
+Cleanup URL-based duplicates from news table.
+
+For each group of rows sharing (agency_key, url), keep the canonical record:
+  1. Prefer records WITH embedding (embedding_generated_at IS NOT NULL)
+  2. Tiebreaker: lowest id (oldest in pipeline)
+
+Deletes non-canonical records + their news_features. Removes orphaned
+Typesense documents if TYPESENSE_API_KEY is set.
+
+Usage:
+  python 011_cleanup_url_duplicates.py --dry-run       # preview only
+  python 011_cleanup_url_duplicates.py --confirm        # execute
+  python 011_cleanup_url_duplicates.py --confirm --batch-size 500
+
+Ref: destaquesgovbr/portal#108, destaquesgovbr/data-platform#138
+"""
+
+import argparse
+import os
+import sys
+import time
+
+
+BATCH_SIZE = 1000
+
+FIND_DUPLICATES_SQL = """
+    SELECT agency_key, url,
+        array_agg(id ORDER BY
+            CASE WHEN embedding_generated_at IS NOT NULL THEN 0 ELSE 1 END,
+            id
+        ) as ids,
+        array_agg(unique_id ORDER BY
+            CASE WHEN embedding_generated_at IS NOT NULL THEN 0 ELSE 1 END,
+            id
+        ) as unique_ids
+    FROM news
+    WHERE url IS NOT NULL
+    GROUP BY agency_key, url
+    HAVING count(*) > 1
+"""
+
+
+def describe() -> str:
+    return "Cleanup de duplicatas por (agency_key, url) na tabela news"
+
+
+def _find_duplicate_groups(conn):
+    cursor = conn.cursor()
+    cursor.execute(FIND_DUPLICATES_SQL)
+    groups = cursor.fetchall()
+    cursor.close()
+    return groups
+
+
+def _delete_batch(conn, unique_ids_to_delete):
+    cursor = conn.cursor()
+
+    cursor.execute(
+        "DELETE FROM news_features WHERE unique_id = ANY(%s)",
+        (unique_ids_to_delete,),
+    )
+    features_deleted = cursor.rowcount
+
+    cursor.execute(
+        "DELETE FROM news WHERE unique_id = ANY(%s)",
+        (unique_ids_to_delete,),
+    )
+    news_deleted = cursor.rowcount
+
+    cursor.close()
+    return news_deleted, features_deleted
+
+
+def _try_delete_from_typesense(unique_ids):
+    api_key = os.getenv("TYPESENSE_API_KEY")
+    host = os.getenv("TYPESENSE_HOST")
+    if not api_key or not host:
+        return 0
+
+    port = os.getenv("TYPESENSE_PORT", "8108")
+    deleted = 0
+    try:
+        import httpx
+
+        for uid in unique_ids:
+            resp = httpx.delete(
+                f"http://{host}:{port}/collections/news/documents/{uid}",
+                headers={"X-TYPESENSE-API-KEY": api_key},
+                timeout=5,
+            )
+            if resp.status_code in (200, 404):
+                deleted += 1
+    except Exception:
+        pass
+    return deleted
+
+
+def migrate(conn, dry_run: bool = False, batch_size: int = BATCH_SIZE) -> dict:
+    groups = _find_duplicate_groups(conn)
+
+    if not groups:
+        return {"groups": 0, "deleted": 0, "message": "No duplicates found"}
+
+    all_to_delete = []
+    preserved_with_embedding = 0
+
+    for agency_key, url, ids, unique_ids in groups:
+        canonical_uid = unique_ids[0]
+        to_delete_uids = unique_ids[1:]
+        all_to_delete.extend(to_delete_uids)
+
+        canonical_id = ids[0]
+        if len(ids) > 1 and canonical_id != min(ids):
+            preserved_with_embedding += 1
+
+    if dry_run:
+        return {
+            "groups": len(groups),
+            "to_delete": len(all_to_delete),
+            "preserved_with_embedding": preserved_with_embedding,
+            "preview": True,
+        }
+
+    t0 = time.time()
+    total_news_deleted = 0
+    total_features_deleted = 0
+
+    for i in range(0, len(all_to_delete), batch_size):
+        batch = all_to_delete[i : i + batch_size]
+        news_del, feat_del = _delete_batch(conn, batch)
+        total_news_deleted += news_del
+        total_features_deleted += feat_del
+
+    typesense_deleted = _try_delete_from_typesense(all_to_delete)
+
+    elapsed = time.time() - t0
+
+    return {
+        "groups": len(groups),
+        "news_deleted": total_news_deleted,
+        "features_deleted": total_features_deleted,
+        "typesense_deleted": typesense_deleted,
+        "preserved_with_embedding": preserved_with_embedding,
+        "elapsed_seconds": round(elapsed, 2),
+    }
+
+
+def rollback(conn, dry_run: bool = False) -> dict:
+    return {
+        "message": "Cleanup is irreversible. Restore from backup: "
+        "pg_restore -d $DATABASE_URL --clean backup_pre_cleanup_*.dump"
+    }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=describe())
+    parser.add_argument("--dry-run", action="store_true", help="Preview without deleting")
+    parser.add_argument("--confirm", action="store_true", help="Execute deletions")
+    parser.add_argument("--batch-size", type=int, default=BATCH_SIZE)
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.confirm:
+        print("Must specify --dry-run or --confirm")
+        sys.exit(1)
+
+    import psycopg2
+
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        print("DATABASE_URL not set")
+        sys.exit(1)
+
+    conn = psycopg2.connect(database_url)
+    try:
+        result = migrate(conn, dry_run=args.dry_run, batch_size=args.batch_size)
+        if not args.dry_run:
+            conn.commit()
+        print(result)
+    except Exception as e:
+        conn.rollback()
+        print(f"Error: {e}")
+        sys.exit(1)
+    finally:
+        conn.close()

--- a/scripts/migrations/011_cleanup_url_duplicates.py
+++ b/scripts/migrations/011_cleanup_url_duplicates.py
@@ -130,6 +130,9 @@ def migrate(conn, dry_run: bool = False, batch_size: int = BATCH_SIZE) -> dict:
         news_del = _delete_batch(conn, batch)
         total_news_deleted += news_del
 
+    # Commit PG (authoritative) before best-effort Typesense cleanup
+    conn.commit()
+
     typesense_deleted = _try_delete_from_typesense(all_to_delete)
 
     elapsed = time.time() - t0
@@ -171,8 +174,6 @@ if __name__ == "__main__":
     conn = psycopg2.connect(database_url)
     try:
         result = migrate(conn, dry_run=args.dry_run, batch_size=args.batch_size)
-        if not args.dry_run:
-            conn.commit()
         print(result)
     except Exception as e:
         conn.rollback()

--- a/scripts/migrations/012_add_url_unique_index.sql
+++ b/scripts/migrations/012_add_url_unique_index.sql
@@ -1,0 +1,12 @@
+-- 012_add_url_unique_index.sql
+-- Cria indice unico parcial em (agency_key, url) para prevenir duplicatas.
+-- DEVE ser executado DEPOIS do cleanup de duplicatas (011).
+-- Ref: destaquesgovbr/portal#108, destaquesgovbr/data-platform#138
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_news_agency_url_unique
+    ON news (agency_key, url)
+    WHERE url IS NOT NULL;
+
+INSERT INTO schema_version (version, description)
+VALUES ('1.6', 'Add unique partial index on (agency_key, url)')
+ON CONFLICT (version) DO NOTHING;

--- a/scripts/migrations/012_add_url_unique_index_rollback.sql
+++ b/scripts/migrations/012_add_url_unique_index_rollback.sql
@@ -1,0 +1,5 @@
+-- Rollback for 012_add_url_unique_index.sql
+
+DROP INDEX IF EXISTS idx_news_agency_url_unique;
+
+DELETE FROM schema_version WHERE version = '1.6';

--- a/src/data_platform/managers/postgres_manager.py
+++ b/src/data_platform/managers/postgres_manager.py
@@ -545,6 +545,7 @@ class PostgresManager:
                 tm.code as most_specific_theme_code,
                 tm.label as most_specific_theme_label,
                 n.tags,
+                n.content_hash,
                 n.content_embedding,
                 nf.features->'sentiment'->>'label' AS sentiment_label,
                 (nf.features->'sentiment'->>'score')::float AS sentiment_score,

--- a/src/data_platform/typesense/collection.py
+++ b/src/data_platform/typesense/collection.py
@@ -96,6 +96,8 @@ COLLECTION_SCHEMA: dict[str, Any] = {
             "facet": True,
             "optional": True,
         },
+        # Deduplication
+        {"name": "content_hash", "type": "string", "facet": True, "optional": True},
         # Feature fields (from news_features JSONB)
         {"name": "sentiment_label", "type": "string", "facet": True, "optional": True},
         {"name": "sentiment_score", "type": "float", "facet": False, "optional": True},

--- a/src/data_platform/typesense/indexer.py
+++ b/src/data_platform/typesense/indexer.py
@@ -166,6 +166,12 @@ def prepare_document(row: pd.Series) -> dict[str, Any]:
         if cleaned_tags:  # Só adiciona se houver tags válidas
             doc["tags"] = cleaned_tags
 
+    # content_hash for cross-agency deduplication (group_by)
+    if pd.notna(row.get("content_hash")):
+        val = str(row["content_hash"]).strip()
+        if val:
+            doc["content_hash"] = val
+
     # Feature fields (optional, from news_features JOIN)
     feature_fields = [
         ("sentiment_label", str),

--- a/tests/unit/test_content_hash_consistency.py
+++ b/tests/unit/test_content_hash_consistency.py
@@ -1,0 +1,41 @@
+"""
+Pinned reference vectors for content_hash consistency between repos.
+
+These values MUST match scraper/tests/unit/test_content_hash.py::test_pinned_vectors.
+If either side diverges, this test breaks before deploy.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+MIGRATION_PATH = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "migrations"
+    / "010_backfill_content_hash.py"
+)
+
+
+@pytest.fixture
+def hash_module():
+    spec = importlib.util.spec_from_file_location("m010", MIGRATION_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_pinned_vectors_cross_repo(hash_module):
+    assert hash_module.normalize_text("Educação Pública") == "educacao publica"
+    assert hash_module.normalize_text("R$ 1 bilhão em 2025") == "r 1 bilhao em 2025"
+    assert hash_module.compute_content_hash("Lula", "conteudo") == "7af6a8c98b1e027b"
+    assert (
+        hash_module.compute_content_hash("Governo anuncia programa", "Texto da notícia")
+        == "ca58538e360baaf4"
+    )
+
+
+def test_empty_returns_none(hash_module):
+    assert hash_module.compute_content_hash("", None) is None
+    assert hash_module.compute_content_hash("", "") is None


### PR DESCRIPTION
## Contexto

O portal exibia notícias duplicadas com `unique_id` diferentes mas conteúdo igual ou quase igual (portal#108). A análise de 11 URLs identificou dois cenários:

- **Mutação de título (80%)**: mesma URL, mesmo órgão — o site edita o título levemente entre raspagens.
- **Republicação cross-agency (20%)**: órgãos diferentes publicam o mesmo press release com conteúdo idêntico.

O plano completo, análise da causa raiz e todas as decisões técnicas estão documentados nesta issue (#138).

**PR relacionado no scraper**: destaquesgovbr/scraper#36 — deve ser mergeado após a migration 009 mas antes das migrations 010-012.

## O que muda

### Migrations 009–012

Sequência obrigatória (o unique index falha se existirem duplicatas):

| Migration | Tipo | Descrição |
|-----------|------|-----------|
| `009_add_content_hash_and_url_index.sql` | SQL | Adiciona coluna `content_hash VARCHAR(16)`, atualiza FK de `news_features` com `ON UPDATE CASCADE`, cria índice não-único em `content_hash` |
| `009_..._rollback.sql` | SQL | Rollback da 009 |
| `010_backfill_content_hash.py` | Python | Backfill em batches de 5000, idempotente. Computa `SHA-256(normalize(title) + "\n" + normalize(content))[:16]` para os ~300k registros existentes |
| `011_cleanup_url_duplicates.py` | Python | Remove duplicatas por `(agency_key, url)`. Critério: preserva registro com `embedding_generated_at IS NOT NULL`; desempate por menor `id`. Suporta `--dry-run`, `--confirm`, `--batch-size`. |
| `012_add_url_unique_index.sql` | SQL | `CREATE UNIQUE INDEX CONCURRENTLY (agency_key, url) WHERE url IS NOT NULL` |
| `012_..._rollback.sql` | SQL | `DROP INDEX` |

### Typesense

- `collection.py`: campo `content_hash` adicionado ao schema como `facet: True, optional: True`
- `indexer.py`: `prepare_document()` inclui `content_hash` no documento
- `managers/postgres_manager.py`: `_build_typesense_query()` seleciona `n.content_hash`

Habilita `group_by=content_hash&group_limit=1` nas queries do portal para colapsar republicações cross-agency.

### Documentação

`docs/database/schema.md` atualizado com a nova coluna, índices e descrição dos campos.

## Arquivos alterados

| Arquivo | Tipo | Descrição |
|---------|------|-----------|
| `scripts/migrations/009_add_content_hash_and_url_index.sql` | NOVO | Migration + atualização FK |
| `scripts/migrations/009_..._rollback.sql` | NOVO | Rollback |
| `scripts/migrations/010_backfill_content_hash.py` | NOVO | Backfill idempotente |
| `scripts/migrations/011_cleanup_url_duplicates.py` | NOVO | Cleanup com dry-run e batches |
| `scripts/migrations/012_add_url_unique_index.sql` | NOVO | Unique index |
| `scripts/migrations/012_..._rollback.sql` | NOVO | Rollback |
| `src/data_platform/typesense/collection.py` | EDIT | Campo `content_hash` no schema |
| `src/data_platform/typesense/indexer.py` | EDIT | `content_hash` em `prepare_document()` |
| `src/data_platform/managers/postgres_manager.py` | EDIT | `n.content_hash` na query Typesense |
| `docs/database/schema.md` | EDIT | Documentação atualizada |

## Plano de execução em produção

```bash
# Passo 0 (pré-requisito): validar premissas sobre URLs
SELECT
  count(*) FILTER (WHERE url ~ '\?')                    AS com_query_params,
  count(*) FILTER (WHERE url ~ '/$')                    AS com_trailing_slash,
  count(*) FILTER (WHERE url ILIKE 'http://%')          AS http_nao_https,
  count(*) FILTER (WHERE url ~* '(utm_|fbclid|gclid)')  AS tracking_params
FROM news WHERE url IS NOT NULL;
-- Go/no-go: todos próximos de 0

# Passo 1: migration 009
psql $DATABASE_URL -f scripts/migrations/009_add_content_hash_and_url_index.sql

# Passo 2: deploy scraper (scraper#36)
# merge do PR no scraper → CI/CD deploya no Cloud Run

# Passo 3: backfill
poetry run python scripts/migrations/010_backfill_content_hash.py

# Passo 4: cleanup (ALTO RISCO — fazer backup antes)
pg_dump $DATABASE_URL -t news -t news_features -Fc -f backup_pre_cleanup_$(date +%Y%m%d_%H%M).dump
poetry run python scripts/migrations/011_cleanup_url_duplicates.py --dry-run
poetry run python scripts/migrations/011_cleanup_url_duplicates.py --confirm --batch-size 1000

# Passo 5: unique index
psql $DATABASE_URL -f scripts/migrations/012_add_url_unique_index.sql

# Passo 6: deploy data-platform (este PR)
# merge → CI/CD deploya workers

# Passo 7: re-indexação Typesense
gh workflow run typesense-full-reload.yaml -f confirm=DELETE
```

## Decisões técnicas relevantes

**Por que `ON UPDATE CASCADE` na FK de `news_features`?**
O two-phase insert nunca altera `unique_id`, mas a migration 006 demonstrou que migrações futuras podem precisar. É medida defensiva de baixo custo (ver D4 em #138).

**Por que `CONCURRENTLY` no unique index?**
Evita lock exclusivo na tabela `news` (~300k rows) durante a criação. O downside é que não pode rodar dentro de uma transação — rollback é `DROP INDEX`.

**Normalização do `content_hash` preserva dígitos**
`\w` em Python inclui `[0-9a-zA-Z_]`. "R$ 1 bilhão" → "r 1 bilhao". Valores numéricos (datas, valores monetários) fazem parte da identidade do conteúdo.

## Testes

```
382 passed — suite completa do data-platform (excluindo falhas pré-existentes não relacionadas)
```

Validado localmente:
- Backfill dos 39 registros do banco de desenvolvimento: todos com `content_hash` preenchido
- Unique index criado sem erros (banco sem duplicatas)
- Re-scrape da Agência Brasil (61 artigos): zero duplicatas criadas após re-indexação