### PR TITLE
feature: adiciona comando typesense-update-schema

### DIFF
--- a/.github/workflows/typesense-schema-update.yaml
+++ b/.github/workflows/typesense-schema-update.yaml
@@ -12,7 +12,7 @@ on:
         description: 'Run incremental sync after schema update to populate new fields'
         required: false
         type: boolean
-        default: false
+        default: true
       sync_start_date:
         description: 'Start date for sync (YYYY-MM-DD, default: 2024-01-01)'
         required: false
@@ -106,6 +106,15 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           poetry run data-platform typesense-update-schema --dry-run 2>&1 | tee -a $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Warn if sync not scheduled
+        if: ${{ !inputs.dry_run && !inputs.sync_after_update }}
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## WARNING" >> $GITHUB_STEP_SUMMARY
+          echo "Schema updated but data NOT synced." >> $GITHUB_STEP_SUMMARY
+          echo "Existing documents will have NULL values for new fields." >> $GITHUB_STEP_SUMMARY
+          echo "Run this workflow again with sync_after_update=true to populate values." >> $GITHUB_STEP_SUMMARY
 
   sync-data:
     name: Sync Data (populate new fields)

--- a/.github/workflows/typesense-schema-update.yaml
+++ b/.github/workflows/typesense-schema-update.yaml
@@ -1,0 +1,193 @@
+name: Typesense Schema Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview changes without applying (default: true)'
+        required: false
+        type: boolean
+        default: true
+      sync_after_update:
+        description: 'Run incremental sync after schema update to populate new fields'
+        required: false
+        type: boolean
+        default: false
+      sync_start_date:
+        description: 'Start date for sync (YYYY-MM-DD, default: 2024-01-01)'
+        required: false
+        type: string
+        default: '2024-01-01'
+
+env:
+  PYTHON_VERSION: '3.12'
+
+jobs:
+  update-schema:
+    name: Update Typesense Schema
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Fetch Typesense Config
+        id: typesense
+        uses: destaquesgovbr/reusable-workflows/actions/fetch-typesense-config@v1
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          secret_name: typesense-write-conn
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Cache Poetry dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --only main
+
+      - name: Update schema (dry-run)
+        if: inputs.dry_run
+        env:
+          TYPESENSE_HOST: ${{ steps.typesense.outputs.host }}
+          TYPESENSE_PORT: ${{ steps.typesense.outputs.port }}
+          TYPESENSE_API_KEY: ${{ steps.typesense.outputs.api_key }}
+        run: |
+          echo "## Schema Update (Dry Run)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          poetry run data-platform typesense-update-schema --dry-run 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Update schema (apply)
+        if: ${{ !inputs.dry_run }}
+        env:
+          TYPESENSE_HOST: ${{ steps.typesense.outputs.host }}
+          TYPESENSE_PORT: ${{ steps.typesense.outputs.port }}
+          TYPESENSE_API_KEY: ${{ steps.typesense.outputs.api_key }}
+        run: |
+          echo "## Schema Update (Applied)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          poetry run data-platform typesense-update-schema 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Verify schema
+        if: ${{ !inputs.dry_run }}
+        env:
+          TYPESENSE_HOST: ${{ steps.typesense.outputs.host }}
+          TYPESENSE_PORT: ${{ steps.typesense.outputs.port }}
+          TYPESENSE_API_KEY: ${{ steps.typesense.outputs.api_key }}
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Verification" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          poetry run data-platform typesense-update-schema --dry-run 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+  sync-data:
+    name: Sync Data (populate new fields)
+    needs: update-schema
+    if: ${{ !inputs.dry_run && inputs.sync_after_update }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Fetch Typesense Config
+        id: typesense
+        uses: destaquesgovbr/reusable-workflows/actions/fetch-typesense-config@v1
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          secret_name: typesense-write-conn
+
+      - name: Fetch Database URL
+        id: database
+        run: |
+          DATABASE_URL=$(gcloud secrets versions access latest --secret=govbrnews-postgres-connection-string)
+          echo "::add-mask::$DATABASE_URL"
+          echo "url=$DATABASE_URL" >> $GITHUB_OUTPUT
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Cache Poetry dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --only main
+
+      - name: Run incremental sync
+        env:
+          TYPESENSE_HOST: ${{ steps.typesense.outputs.host }}
+          TYPESENSE_PORT: ${{ steps.typesense.outputs.port }}
+          TYPESENSE_API_KEY: ${{ steps.typesense.outputs.api_key }}
+          DATABASE_URL: ${{ steps.database.outputs.url }}
+        run: |
+          END_DATE=$(date +%Y-%m-%d)
+          echo "## Incremental Sync" >> $GITHUB_STEP_SUMMARY
+          echo "Date range: ${{ inputs.sync_start_date }} to $END_DATE" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          poetry run data-platform sync-typesense \
+            --start-date "${{ inputs.sync_start_date }}" \
+            --end-date "$END_DATE" \
+            --full-sync 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Verify collection
+        env:
+          TYPESENSE_HOST: ${{ steps.typesense.outputs.host }}
+          TYPESENSE_PORT: ${{ steps.typesense.outputs.port }}
+          TYPESENSE_API_KEY: ${{ steps.typesense.outputs.api_key }}
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Post-Sync Verification" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          poetry run data-platform typesense-list 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/src/data_platform/cli.py
+++ b/src/data_platform/cli.py
@@ -5,6 +5,7 @@ Commands:
 - sync-hf: Sync PostgreSQL data to HuggingFace
 - migrate: Migrate data from HuggingFace to PostgreSQL
 - sync-typesense: Sync news from PostgreSQL to Typesense
+- typesense-update-schema: Update collection schema (add missing fields)
 - typesense-delete: Delete a Typesense collection
 - typesense-list: List all Typesense collections
 
@@ -94,6 +95,33 @@ def sync_typesense(
         f"Typesense sync completed: {stats['total_indexed']} indexed, "
         f"{stats['errors']} errors, {stats['total_fetched']} fetched"
     )
+
+
+@app.command("typesense-update-schema")
+def typesense_update_schema(
+    collection_name: str = typer.Option("news", help="Collection name to update"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without applying"),
+) -> None:
+    """
+    Update Typesense collection schema by adding missing fields.
+
+    Compares the desired schema (defined in code) with the live collection
+    and adds any fields that are missing. Does not remove or alter existing fields.
+    """
+    from data_platform.jobs.typesense import update_typesense_schema
+
+    result = update_typesense_schema(collection_name=collection_name, dry_run=dry_run)
+
+    if result["errors"]:
+        logging.error(f"Schema update finished with {len(result['errors'])} error(s)")
+        for err in result["errors"]:
+            logging.error(f"  {err['field']}: {err['error']}")
+        raise typer.Exit(code=1)
+
+    if result["added"]:
+        logging.info(f"Added {len(result['added'])} field(s): {result['added']}")
+    else:
+        logging.info("Schema is up to date — no changes needed")
 
 
 @app.command("typesense-delete")

--- a/src/data_platform/jobs/typesense/__init__.py
+++ b/src/data_platform/jobs/typesense/__init__.py
@@ -6,6 +6,7 @@ from data_platform.jobs.typesense.sync_job import sync_to_typesense
 from data_platform.jobs.typesense.collection_ops import (
     delete_typesense_collection,
     list_typesense_collections,
+    update_typesense_schema,
     create_search_key,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "sync_to_typesense",
     "delete_typesense_collection",
     "list_typesense_collections",
+    "update_typesense_schema",
     "create_search_key",
 ]

--- a/src/data_platform/jobs/typesense/collection_ops.py
+++ b/src/data_platform/jobs/typesense/collection_ops.py
@@ -11,6 +11,7 @@ from data_platform.typesense import (
     get_client,
     delete_collection,
     list_collections,
+    update_schema,
     COLLECTION_NAME,
 )
 
@@ -46,6 +47,29 @@ def list_typesense_collections() -> list[dict[str, Any]]:
     """
     client = get_client()
     return list_collections(client)
+
+
+def update_typesense_schema(
+    collection_name: str = COLLECTION_NAME,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """
+    Atualiza o schema da coleção Typesense, adicionando campos faltantes.
+
+    Args:
+        collection_name: Nome da coleção
+        dry_run: Se True, apenas reporta diferenças sem aplicar
+
+    Returns:
+        Dicionário com resultado (added, already_exists, errors)
+    """
+    logger.info(
+        f"Atualizando schema da coleção '{collection_name}'"
+        f"{' [DRY-RUN]' if dry_run else ''}..."
+    )
+
+    client = get_client()
+    return update_schema(client, collection_name, dry_run=dry_run)
 
 
 def create_search_key(

--- a/src/data_platform/typesense/__init__.py
+++ b/src/data_platform/typesense/__init__.py
@@ -15,6 +15,7 @@ from data_platform.typesense.collection import (
     create_collection,
     delete_collection,
     list_collections,
+    update_schema,
 )
 from data_platform.typesense.indexer import (
     index_documents,
@@ -33,6 +34,7 @@ __all__ = [
     "create_collection",
     "delete_collection",
     "list_collections",
+    "update_schema",
     # Indexer
     "index_documents",
     "prepare_document",

--- a/src/data_platform/typesense/collection.py
+++ b/src/data_platform/typesense/collection.py
@@ -251,6 +251,84 @@ def delete_collection(
         return False
 
 
+def update_schema(
+    client: typesense.Client,
+    collection_name: str = COLLECTION_NAME,
+    schema: dict[str, Any] | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """
+    Atualiza o schema de uma coleção existente, adicionando campos faltantes.
+
+    Compara o schema desejado (código) com o schema live (Typesense) e adiciona
+    campos que existem no código mas não na coleção. Não remove nem altera campos
+    existentes.
+
+    Args:
+        client: Cliente Typesense
+        collection_name: Nome da coleção
+        schema: Schema desejado (default: COLLECTION_SCHEMA)
+        dry_run: Se True, apenas reporta diferenças sem aplicar
+
+    Returns:
+        Dicionário com resultado:
+            - added: lista de nomes de campos adicionados
+            - already_exists: lista de campos que já existiam
+            - errors: lista de erros (campo + mensagem)
+    """
+    schema_to_use = schema or COLLECTION_SCHEMA
+    desired_fields = {f["name"]: f for f in schema_to_use["fields"]}
+
+    result: dict[str, Any] = {"added": [], "already_exists": [], "errors": []}
+
+    try:
+        collection_info = client.collections[collection_name].retrieve()
+    except ObjectNotFound:
+        raise ValueError(
+            f"Coleção '{collection_name}' não encontrada. "
+            "Use create_collection() para criar uma nova."
+        )
+
+    live_field_names = {f["name"] for f in collection_info.get("fields", [])}
+
+    missing_fields = []
+    for name, field_def in desired_fields.items():
+        if name in live_field_names:
+            result["already_exists"].append(name)
+        else:
+            missing_fields.append(field_def)
+
+    if not missing_fields:
+        logger.info("Schema está atualizado — nenhum campo faltante")
+        return result
+
+    logger.info(
+        f"Encontrados {len(missing_fields)} campo(s) faltante(s): "
+        f"{[f['name'] for f in missing_fields]}"
+    )
+
+    if dry_run:
+        result["added"] = [f["name"] for f in missing_fields]
+        logger.info("[DRY-RUN] Nenhuma alteração aplicada")
+        return result
+
+    for field_def in missing_fields:
+        field_name = field_def["name"]
+        try:
+            client.collections[collection_name].update({"fields": [field_def]})
+            result["added"].append(field_name)
+            logger.info(f"  + Campo '{field_name}' adicionado com sucesso")
+        except Exception as e:
+            result["errors"].append({"field": field_name, "error": str(e)})
+            logger.error(f"  ! Erro ao adicionar campo '{field_name}': {e}")
+
+    logger.info(
+        f"Schema update concluído: {len(result['added'])} adicionados, "
+        f"{len(result['errors'])} erros"
+    )
+    return result
+
+
 def list_collections(client: typesense.Client) -> list[dict[str, Any]]:
     """
     Lista todas as coleções disponíveis.

--- a/src/data_platform/typesense/collection.py
+++ b/src/data_platform/typesense/collection.py
@@ -251,6 +251,19 @@ def delete_collection(
         return False
 
 
+_MAX_RETRIES = 3
+_RETRY_BASE_DELAY = 2
+
+
+def _sanitize_error(e: Exception) -> str:
+    """Remove detalhes sensíveis de mensagens de erro."""
+    msg = str(e)
+    sensitive_keywords = ["api_key", "apikey", "token", "password", "secret"]
+    if any(kw in msg.lower() for kw in sensitive_keywords):
+        return f"{type(e).__name__}: [details omitted for security]"
+    return msg
+
+
 def update_schema(
     client: typesense.Client,
     collection_name: str = COLLECTION_NAME,
@@ -261,8 +274,14 @@ def update_schema(
     Atualiza o schema de uma coleção existente, adicionando campos faltantes.
 
     Compara o schema desejado (código) com o schema live (Typesense) e adiciona
-    campos que existem no código mas não na coleção. Não remove nem altera campos
-    existentes.
+    campos que existem no código mas não na coleção via PATCH atômico.
+
+    Comportamento:
+    - Não remove campos que existem apenas no Typesense (safe)
+    - Não altera definição de campos existentes (type, facet, etc.)
+    - Apenas adiciona campos novos com base no nome
+    - Campos existentes nos documentos não são populados automaticamente
+      (rodar sync após update para popular valores)
 
     Args:
         client: Cliente Typesense
@@ -312,15 +331,31 @@ def update_schema(
         logger.info("[DRY-RUN] Nenhuma alteração aplicada")
         return result
 
-    for field_def in missing_fields:
-        field_name = field_def["name"]
+    # Batch update — adiciona todos os campos em uma única chamada PATCH (atômico)
+    for attempt in range(1, _MAX_RETRIES + 1):
         try:
-            client.collections[collection_name].update({"fields": [field_def]})
-            result["added"].append(field_name)
-            logger.info(f"  + Campo '{field_name}' adicionado com sucesso")
+            client.collections[collection_name].update({"fields": missing_fields})
+            result["added"] = [f["name"] for f in missing_fields]
+            for f in missing_fields:
+                logger.info(f"  + Campo '{f['name']}' adicionado")
+            break
         except Exception as e:
-            result["errors"].append({"field": field_name, "error": str(e)})
-            logger.error(f"  ! Erro ao adicionar campo '{field_name}': {e}")
+            error_msg = _sanitize_error(e)
+            if attempt < _MAX_RETRIES:
+                delay = _RETRY_BASE_DELAY ** attempt
+                logger.warning(
+                    f"Tentativa {attempt}/{_MAX_RETRIES} falhou: {error_msg}. "
+                    f"Retentando em {delay}s..."
+                )
+                time.sleep(delay)
+            else:
+                logger.error(
+                    f"Falha após {_MAX_RETRIES} tentativas: {error_msg}"
+                )
+                for f in missing_fields:
+                    result["errors"].append(
+                        {"field": f["name"], "error": error_msg}
+                    )
 
     logger.info(
         f"Schema update concluído: {len(result['added'])} adicionados, "

--- a/tests/unit/typesense/test_collection.py
+++ b/tests/unit/typesense/test_collection.py
@@ -218,8 +218,32 @@ class TestUpdateSchema:
         with pytest.raises(ValueError, match="não encontrada"):
             update_schema(mock_client)
 
-    def test_handles_partial_failure(self):
-        """Records errors for fields that fail to add."""
+    @patch("data_platform.typesense.collection.time.sleep")
+    def test_retries_on_failure_then_succeeds(self, mock_sleep):
+        """Retries on transient failure and succeeds on subsequent attempt."""
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.retrieve.return_value = {"fields": []}
+        mock_collection.update.side_effect = [Exception("Timeout"), {}]
+        mock_client.collections.__getitem__.return_value = mock_collection
+
+        schema = {
+            "name": "news",
+            "fields": [
+                {"name": "content_hash", "type": "string", "facet": True, "optional": True},
+            ],
+        }
+
+        result = update_schema(mock_client, schema=schema)
+
+        assert "content_hash" in result["added"]
+        assert result["errors"] == []
+        assert mock_collection.update.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("data_platform.typesense.collection.time.sleep")
+    def test_records_errors_after_max_retries(self, mock_sleep):
+        """Records errors for all fields after exhausting retries."""
         mock_client = MagicMock()
         mock_collection = MagicMock()
         mock_collection.retrieve.return_value = {"fields": []}
@@ -238,6 +262,38 @@ class TestUpdateSchema:
         assert result["added"] == []
         assert len(result["errors"]) == 1
         assert result["errors"][0]["field"] == "bad_field"
+        assert mock_collection.update.call_count == 3
+
+    def test_batch_adds_multiple_fields_atomically(self):
+        """Adds multiple fields in a single PATCH call."""
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.retrieve.return_value = {"fields": []}
+        mock_collection.update.return_value = {}
+        mock_client.collections.__getitem__.return_value = mock_collection
+
+        schema = {
+            "name": "news",
+            "fields": [
+                {"name": "field_a", "type": "string", "facet": True, "optional": True},
+                {"name": "field_b", "type": "int32", "facet": False, "optional": True},
+            ],
+        }
+
+        result = update_schema(mock_client, schema=schema)
+
+        assert "field_a" in result["added"]
+        assert "field_b" in result["added"]
+        mock_collection.update.assert_called_once_with({"fields": schema["fields"]})
+
+    def test_sanitizes_sensitive_error_messages(self):
+        """Does not expose API keys in error messages."""
+        from data_platform.typesense.collection import _sanitize_error
+
+        e = Exception("Connection to host with api_key=abc123 failed")
+        sanitized = _sanitize_error(e)
+        assert "abc123" not in sanitized
+        assert "omitted" in sanitized
 
 
 class TestListCollections:

--- a/tests/unit/typesense/test_collection.py
+++ b/tests/unit/typesense/test_collection.py
@@ -13,6 +13,7 @@ from data_platform.typesense.collection import (
     create_collection,
     delete_collection,
     list_collections,
+    update_schema,
 )
 
 
@@ -126,6 +127,117 @@ class TestDeleteCollection:
             result = delete_collection(mock_client, confirm=True)
 
         assert result is True
+
+
+class TestUpdateSchema:
+    """Tests for update_schema() function."""
+
+    def test_adds_missing_fields(self):
+        """Adds fields that exist in schema but not in live collection."""
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.retrieve.return_value = {
+            "fields": [
+                {"name": "unique_id", "type": "string", "facet": True},
+                {"name": "published_at", "type": "int64", "facet": False},
+            ]
+        }
+        mock_collection.update.return_value = {}
+        mock_client.collections.__getitem__.return_value = mock_collection
+
+        schema = {
+            "name": "news",
+            "fields": [
+                {"name": "unique_id", "type": "string", "facet": True},
+                {"name": "published_at", "type": "int64", "facet": False},
+                {"name": "content_hash", "type": "string", "facet": True, "optional": True},
+            ],
+        }
+
+        result = update_schema(mock_client, schema=schema)
+
+        assert "content_hash" in result["added"]
+        assert "unique_id" in result["already_exists"]
+        assert "published_at" in result["already_exists"]
+        mock_collection.update.assert_called_once_with(
+            {"fields": [{"name": "content_hash", "type": "string", "facet": True, "optional": True}]}
+        )
+
+    def test_no_changes_when_schema_matches(self):
+        """Returns empty added list when schema is already up to date."""
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.retrieve.return_value = {
+            "fields": [
+                {"name": "unique_id", "type": "string", "facet": True},
+                {"name": "title", "type": "string", "facet": False},
+            ]
+        }
+        mock_client.collections.__getitem__.return_value = mock_collection
+
+        schema = {
+            "name": "news",
+            "fields": [
+                {"name": "unique_id", "type": "string", "facet": True},
+                {"name": "title", "type": "string", "facet": False},
+            ],
+        }
+
+        result = update_schema(mock_client, schema=schema)
+
+        assert result["added"] == []
+        assert len(result["already_exists"]) == 2
+        mock_collection.update.assert_not_called()
+
+    def test_dry_run_does_not_apply(self):
+        """Dry run reports missing fields without applying."""
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.retrieve.return_value = {"fields": []}
+        mock_client.collections.__getitem__.return_value = mock_collection
+
+        schema = {
+            "name": "news",
+            "fields": [
+                {"name": "content_hash", "type": "string", "facet": True, "optional": True},
+            ],
+        }
+
+        result = update_schema(mock_client, schema=schema, dry_run=True)
+
+        assert "content_hash" in result["added"]
+        mock_collection.update.assert_not_called()
+
+    def test_raises_on_nonexistent_collection(self):
+        """Raises ValueError if collection does not exist."""
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.retrieve.side_effect = ObjectNotFound("Not found")
+        mock_client.collections.__getitem__.return_value = mock_collection
+
+        with pytest.raises(ValueError, match="não encontrada"):
+            update_schema(mock_client)
+
+    def test_handles_partial_failure(self):
+        """Records errors for fields that fail to add."""
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.retrieve.return_value = {"fields": []}
+        mock_collection.update.side_effect = Exception("Bad field type")
+        mock_client.collections.__getitem__.return_value = mock_collection
+
+        schema = {
+            "name": "news",
+            "fields": [
+                {"name": "bad_field", "type": "invalid", "facet": True},
+            ],
+        }
+
+        result = update_schema(mock_client, schema=schema)
+
+        assert result["added"] == []
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["field"] == "bad_field"
 
 
 class TestListCollections:


### PR DESCRIPTION
## Resumo

Adiciona a capacidade de atualizar o schema de uma collection Typesense existente sem deletar dados ou causar downtime.

- CLI: `poetry run data-platform typesense-update-schema [--dry-run]`
- Workflow: `typesense-schema-update.yaml` (manual, com opção de sync após update)

## Contexto

O campo `content_hash` foi adicionado ao schema no código (PR #144) mas a collection live no Typesense não foi atualizada. Sem esse campo no schema, queries com `group_by: 'content_hash'` falham com 404.

Até agora, a única opção era `full-reload` (deleta + recria a collection), que causa downtime. Esta feature permite adicionar campos de forma incremental.

## Mudanças

| Arquivo | O que faz |
|---------|-----------|
| `typesense/collection.py` | Nova função `update_schema()` — compara schema desejado vs live, adiciona campos faltantes via PATCH |
| `typesense/__init__.py` | Exporta `update_schema` |
| `jobs/typesense/collection_ops.py` | Nova função `update_typesense_schema()` (wrapper com client) |
| `jobs/typesense/__init__.py` | Exporta `update_typesense_schema` |
| `cli.py` | Novo comando `typesense-update-schema` com `--dry-run` |
| `.github/workflows/typesense-schema-update.yaml` | Workflow manual: dry-run/apply + sync opcional |
| `tests/unit/typesense/test_collection.py` | 5 testes unitários |

## Uso

```bash
# Preview (não altera nada)
poetry run data-platform typesense-update-schema --dry-run

# Aplicar campos faltantes
poetry run data-platform typesense-update-schema
```

### Workflow

Inputs:
- `dry_run` (default: true) — preview ou aplicar
- `sync_after_update` (default: false) — rodar incremental sync após update para popular valores nos docs
- `sync_start_date` (default: 2024-01-01) — data inicial do sync

## Testes

```
============================== 18 passed in 2.02s ==============================
```