### PR TITLE
fix: adicionar identity token nas chamadas ao Cloud Run

### DIFF
--- a/src/data_platform/dags/generate_video_thumbnails.py
+++ b/src/data_platform/dags/generate_video_thumbnails.py
@@ -18,17 +18,20 @@ from airflow.decorators import dag, task
 from airflow.hooks.base import BaseHook
 from airflow.models import Variable
 
+from data_platform.dags.utils.cloud_run import get_id_token
+
 logger = logging.getLogger(__name__)
 
 WORKER_REQUEST_TIMEOUT = 60
 
 
-def _process_one(article: dict, worker_url: str) -> tuple[str, str]:
+def _process_one(article: dict, worker_url: str, token: str) -> tuple[str, str]:
     """Envia um artigo para o thumbnail worker. Retorna (unique_id, status).
 
     Args:
         article: Dict with unique_id key.
         worker_url: Base URL of the thumbnail worker.
+        token: Identity token for Cloud Run authentication.
 
     Returns:
         Tuple of (unique_id, status).
@@ -45,6 +48,7 @@ def _process_one(article: dict, worker_url: str) -> tuple[str, str]:
                     "attributes": {},
                 }
             },
+            headers={"Authorization": f"Bearer {token}"},
             timeout=WORKER_REQUEST_TIMEOUT,
         )
         resp.raise_for_status()
@@ -118,11 +122,13 @@ def generate_video_thumbnails_dag():
 
         worker_url = Variable.get("thumbnail_worker_url")
         max_workers = int(Variable.get("thumbnail_max_workers", default_var="5"))
+        token = get_id_token(worker_url)
         summary = {"processed": 0, "generated": 0, "failed": 0, "skipped": 0}
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = {
-                executor.submit(_process_one, article, worker_url): article for article in articles
+                executor.submit(_process_one, article, worker_url, token): article
+                for article in articles
             }
             for future in concurrent.futures.as_completed(futures):
                 unique_id, status = future.result()

--- a/src/data_platform/dags/utils/cloud_run.py
+++ b/src/data_platform/dags/utils/cloud_run.py
@@ -1,0 +1,25 @@
+"""Authenticated HTTP calls to Cloud Run services."""
+
+import google.auth.transport.requests
+import google.oauth2.id_token
+import requests
+
+
+def get_id_token(audience: str) -> str:
+    """Fetch an identity token for the given audience (Cloud Run URL base)."""
+    auth_req = google.auth.transport.requests.Request()
+    return google.oauth2.id_token.fetch_id_token(auth_req, audience)
+
+
+def post(url: str, json: dict, timeout: int) -> requests.Response:
+    """Authenticated POST to a Cloud Run service using an identity token."""
+    audience = "/".join(url.split("/", 3)[:3])
+    token = get_id_token(audience)
+    resp = requests.post(
+        url,
+        json=json,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return resp

--- a/src/data_platform/dags/verify_news_integrity.py
+++ b/src/data_platform/dags/verify_news_integrity.py
@@ -9,10 +9,11 @@ delegando o trabalho HTTP para o Scraper Cloud Run via POST /verify/integrity.
 import logging
 from datetime import datetime, timedelta
 
-import requests
 from airflow.decorators import dag, task
 from airflow.hooks.base import BaseHook
 from airflow.models import Variable
+
+from data_platform.dags.utils.cloud_run import post as cloud_run_post
 
 logger = logging.getLogger(__name__)
 
@@ -79,12 +80,7 @@ def verify_news_integrity_dag():
         url = f"{scraper_url}/verify/integrity"
 
         logger.info(f"Enviando {len(articles)} artigos para {url}")
-        resp = requests.post(
-            url,
-            json={"articles": articles},
-            timeout=SCRAPER_REQUEST_TIMEOUT,
-        )
-        resp.raise_for_status()
+        resp = cloud_run_post(url, json={"articles": articles}, timeout=SCRAPER_REQUEST_TIMEOUT)
 
         data = resp.json()
         summary = data.get("summary", {})

--- a/tests/unit/dags/test_cloud_run_helper.py
+++ b/tests/unit/dags/test_cloud_run_helper.py
@@ -1,0 +1,44 @@
+"""Unit tests for the Cloud Run authentication helper."""
+
+from unittest.mock import Mock, patch
+
+from data_platform.dags.utils.cloud_run import get_id_token, post
+
+
+class TestGetIdToken:
+    @patch("data_platform.dags.utils.cloud_run.google.oauth2.id_token.fetch_id_token")
+    @patch("data_platform.dags.utils.cloud_run.google.auth.transport.requests.Request")
+    def test_fetches_token_for_audience(self, mock_request_cls, mock_fetch) -> None:
+        mock_fetch.return_value = "test-token"
+        token = get_id_token("https://my-service.run.app")
+        mock_fetch.assert_called_once_with(mock_request_cls.return_value, "https://my-service.run.app")
+        assert token == "test-token"
+
+
+class TestPost:
+    @patch("data_platform.dags.utils.cloud_run.requests.post")
+    @patch("data_platform.dags.utils.cloud_run.get_id_token")
+    def test_sends_auth_header(self, mock_get_token, mock_post) -> None:
+        mock_get_token.return_value = "id-token-123"
+        mock_post.return_value = Mock(status_code=200, raise_for_status=Mock())
+
+        resp = post("https://svc.run.app/endpoint", json={"key": "val"}, timeout=30)
+
+        mock_get_token.assert_called_once_with("https://svc.run.app")
+        mock_post.assert_called_once_with(
+            "https://svc.run.app/endpoint",
+            json={"key": "val"},
+            headers={"Authorization": "Bearer id-token-123"},
+            timeout=30,
+        )
+        assert resp.status_code == 200
+
+    @patch("data_platform.dags.utils.cloud_run.requests.post")
+    @patch("data_platform.dags.utils.cloud_run.get_id_token")
+    def test_extracts_audience_from_url_with_path(self, mock_get_token, mock_post) -> None:
+        mock_get_token.return_value = "tok"
+        mock_post.return_value = Mock(raise_for_status=Mock())
+
+        post("https://my-service-abc123.a.run.app/verify/integrity", json={}, timeout=10)
+
+        mock_get_token.assert_called_once_with("https://my-service-abc123.a.run.app")

--- a/tests/unit/dags/test_generate_video_thumbnails.py
+++ b/tests/unit/dags/test_generate_video_thumbnails.py
@@ -143,14 +143,14 @@ class TestProcessOne:
             json=Mock(return_value={"status": "generated"}),
             raise_for_status=Mock(),
         )
-        uid, status = process_one({"unique_id": "a1"}, "http://worker")
+        uid, status = process_one({"unique_id": "a1"}, "http://worker", "fake-token")
         assert uid == "a1"
         assert status == "generated"
 
     @patch("requests.post")
     def test_returns_failed_on_exception(self, mock_post, process_one) -> None:
         mock_post.side_effect = Exception("connection refused")
-        uid, status = process_one({"unique_id": "a1"}, "http://worker")
+        uid, status = process_one({"unique_id": "a1"}, "http://worker", "fake-token")
         assert uid == "a1"
         assert status == "failed"
 
@@ -162,9 +162,22 @@ class TestProcessOne:
             json=Mock(return_value={"status": "generated"}),
             raise_for_status=Mock(),
         )
-        process_one({"unique_id": "test_uid"}, "http://worker")
+        process_one({"unique_id": "test_uid"}, "http://worker", "fake-token")
 
         call_kwargs = mock_post.call_args[1]
         envelope = call_kwargs["json"]
         decoded = json.loads(base64.b64decode(envelope["message"]["data"]))
         assert decoded == {"unique_id": "test_uid"}
+
+    @patch("requests.post")
+    def test_sends_auth_header(self, mock_post, process_one) -> None:
+        mock_post.return_value = Mock(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            json=Mock(return_value={"status": "generated"}),
+            raise_for_status=Mock(),
+        )
+        process_one({"unique_id": "a1"}, "http://worker", "my-token")
+
+        call_kwargs = mock_post.call_args[1]
+        assert call_kwargs["headers"]["Authorization"] == "Bearer my-token"


### PR DESCRIPTION
## Summary

- DAGs `verify_news_integrity` e `generate_video_thumbnails` falhavam com **403 Forbidden** ao chamar Cloud Run sem identity token
- Cria helper reutilizável `dags/utils/cloud_run.py` com `get_id_token()` e `post()` autenticado
- Atualiza ambas as DAGs para usar chamadas autenticadas

Closes #149

## Test plan

- [x] 486 testes unitários passando (incluindo 4 novos testes de auth)
- [ ] Após merge/deploy, verificar que a DAG `verify_news_integrity` executa com `state=success` no Composer
- [ ] Verificar que `generate_video_thumbnails` não regride