### PR TITLE
fix: substituir ::jsonb por CAST para compatibilidade SQLAlchemy (#154)

### DIFF
--- a/src/data_platform/jobs/integrity/results.py
+++ b/src/data_platform/jobs/integrity/results.py
@@ -10,12 +10,12 @@ logger = logging.getLogger(__name__)
 
 UPSERT_SQL = text("""
     INSERT INTO news_features (unique_id, features)
-    VALUES (:uid, jsonb_build_object('integrity', :integrity_fields::jsonb))
+    VALUES (:uid, jsonb_build_object('integrity', CAST(:integrity_fields AS jsonb)))
     ON CONFLICT (unique_id) DO UPDATE
     SET features = jsonb_set(
         COALESCE(news_features.features, '{}'),
         '{integrity}',
-        COALESCE(news_features.features -> 'integrity', '{}') || :integrity_fields::jsonb
+        COALESCE(news_features.features -> 'integrity', '{}') || CAST(:integrity_fields AS jsonb)
     ),
         updated_at = NOW()
 """)


### PR DESCRIPTION
## Descrição

Corrige `SyntaxError` no psycopg2 causado por ambiguidade na sintaxe `:integrity_fields::jsonb` dentro de `text()` do SQLAlchemy.

### Problema

O SQLAlchemy `text()` interpreta `:` como delimitador de bind parameters. Na expressão `:integrity_fields::jsonb`, o parser não consegue desambiguar onde termina o nome do parâmetro e onde começa o operador de cast `::` do PostgreSQL, resultando em erro:

```
psycopg2.errors.SyntaxError: syntax error at or near ":"
```

### Solução

Substituídas **2 ocorrências** de `:integrity_fields::jsonb` por `CAST(:integrity_fields AS jsonb)` na constante `UPSERT_SQL` de `results.py` (linhas 13 e 18).

A sintaxe `CAST(... AS jsonb)` é SQL padrão e elimina completamente a ambiguidade, mantendo a funcionalidade idêntica.

## Impacto

- ✅ Todos os **30 testes unitários** de integridade passam
- ✅ Nenhum teste quebrado pela mudança
- ✅ Cobertura de `results.py`: **95%**

## Contexto

Este bug é **pré-existente desde o PR #104** mas só se manifestou agora porque as tasks anteriores da DAG `verify_news_integrity` falhavam antes de chegar ao `save_results`. Com os fixes recentes (#150, #152, scraper#40, scraper#42), a task `save_results` executa pela primeira vez e expôs o erro.

## Checklist

- [x] Testes unitários passam
- [x] Código segue padrões do projeto
- [x] Fix validado contra issue #154

Fixes #154