### PR TITLE
fix: nullificar image_url relativas do Plone na tabela news (scraper#49)

### DIFF
--- a/scripts/migrations/013_nullify_relative_image_urls.sql
+++ b/scripts/migrations/013_nullify_relative_image_urls.sql
@@ -7,6 +7,6 @@ BEGIN;
 UPDATE news
 SET image_url = NULL
 WHERE image_url IS NOT NULL
-  AND image_url NOT LIKE 'https://%';
+  AND image_url NOT LIKE 'http%';
 
 COMMIT;

--- a/scripts/migrations/013_nullify_relative_image_urls.sql
+++ b/scripts/migrations/013_nullify_relative_image_urls.sql
@@ -1,0 +1,12 @@
+-- Migration 013: Nullify relative image URLs stored from Plone resolveuid paths
+-- Issue: scraper#49 - webscraper stored relative paths without absolutization
+-- Safety: Sets to NULL so integrity checker can re-discover absolute URL on next run
+
+BEGIN;
+
+UPDATE news
+SET image_url = NULL
+WHERE image_url IS NOT NULL
+  AND image_url NOT LIKE 'https://%';
+
+COMMIT;

--- a/scripts/migrations/013_nullify_relative_image_urls_rollback.sql
+++ b/scripts/migrations/013_nullify_relative_image_urls_rollback.sql
@@ -1,0 +1,5 @@
+-- Rollback 013: No safe automatic rollback
+-- Original values were invalid relative paths (e.g. resolveuid/...)
+-- Recovery: re-scrape affected articles to populate correct absolute URLs
+
+SELECT 'No automatic rollback available. Original values were invalid relative paths.' AS notice;


### PR DESCRIPTION
## Contexto

O webscraper armazenou `image_url` com paths relativos do Plone (ex: `resolveuid/6d007f.../@@images/image/Imagem-6C`) sem absolutizar. Essas URLs falham na validacao SSRF do endpoint `/verify/integrity`, causando 100% de falha na DAG `verify_news_integrity`.

O fix no scraper (scraper#50) corrige o problema na origem, mas dados invalidos ja existem no banco.

## Mudanca

Migration 013: `UPDATE news SET image_url = NULL WHERE image_url NOT LIKE 'https://%'`

## Estrategia

- Setar NULL em vez de tentar converter (nao ha forma confiavel de reconstruir a URL absoluta a partir do path relativo)
- O `check_content` do integrity checker re-descobre a `new_image_url` absoluta na proxima verificacao do artigo
- Rollback nao e automatizavel (valores originais eram invalidos)

## Execucao

1. Verificar linhas afetadas: `SELECT COUNT(*) FROM news WHERE image_url IS NOT NULL AND image_url NOT LIKE 'https://%';`
2. Aplicar migration
3. Aguardar proximo ciclo da DAG `verify_news_integrity` para re-popular

## Dependencias

- Depende de scraper#50 estar deployado primeiro (senao novas URLs relativas continuam entrando)

## Riscos

- **Baixo**: so afeta linhas com URLs que ja eram invalidas (nao comecam com `https://`)
- Nenhuma URL valida e afetada pelo filtro