### PR TITLE
fix: filtrar URLs fora da allowlist SSRF no batch de integridade

### DIFF
--- a/scripts/migrations/014_nullify_disallowed_image_urls.sql
+++ b/scripts/migrations/014_nullify_disallowed_image_urls.sql
@@ -1,0 +1,19 @@
+-- Migration 014: Nullify image URLs with domains outside the SSRF allowlist
+-- These URLs are rejected by the scraper's /verify/integrity endpoint,
+-- causing the entire batch to fail with 422.
+-- Setting to NULL allows the integrity checker to re-discover valid URLs.
+
+BEGIN;
+
+UPDATE news
+SET image_url = NULL
+WHERE image_url IS NOT NULL
+  AND image_url NOT LIKE 'https://www.gov.br/%'
+  AND image_url NOT LIKE 'https://agenciabrasil.ebc.com.br/%'
+  AND image_url NOT LIKE 'https://imagens.ebc.com.br/%'
+  AND image_url NOT LIKE 'https://memoria.ebc.com.br/%'
+  AND image_url NOT LIKE 'https://tvbrasil.ebc.com.br/%'
+  AND image_url NOT LIKE 'https://live.staticflickr.com/%'
+  AND image_url NOT LIKE 'https://storage.googleapis.com/destaquesgovbr-thumbnails/%';
+
+COMMIT;

--- a/scripts/migrations/014_nullify_disallowed_image_urls_rollback.sql
+++ b/scripts/migrations/014_nullify_disallowed_image_urls_rollback.sql
@@ -1,0 +1,6 @@
+-- Rollback for migration 014
+-- Cannot restore original URLs; re-scraping required to rediscover them.
+-- This is a no-op placeholder for consistency.
+
+SELECT 'Rollback not possible: original image_url values were not preserved. '
+       'Re-scraping affected articles will rediscover valid URLs.' AS warning;

--- a/src/data_platform/jobs/integrity/priority.py
+++ b/src/data_platform/jobs/integrity/priority.py
@@ -70,6 +70,25 @@ PRIORITY_QUERY = text("""
 # Proporção de artigos que devem ter check_content ativado (os mais recentes)
 CONTENT_CHECK_RATIO = 0.25
 
+# Allowlist de domínios aceitos pelo endpoint /verify/integrity do scraper.
+# Espelha _ALLOWED_URL_PREFIXES em govbr_scraper/api.py.
+ALLOWED_URL_PREFIXES = (
+    "https://www.gov.br/",
+    "https://agenciabrasil.ebc.com.br/",
+    "https://imagens.ebc.com.br/",
+    "https://memoria.ebc.com.br/",
+    "https://tvbrasil.ebc.com.br/",
+    "https://live.staticflickr.com/",
+    "https://storage.googleapis.com/destaquesgovbr-thumbnails/",
+)
+
+
+def _is_allowed_url(url: str | None) -> bool:
+    """Verifica se uma URL pertence à allowlist de domínios aceitos."""
+    if not url:
+        return True
+    return any(url.startswith(prefix) for prefix in ALLOWED_URL_PREFIXES)
+
 
 def fetch_priority_batch(db_url: str, batch_size: int = 400) -> list[dict]:
     """Busca artigos priorizados para verificação de integridade.
@@ -97,20 +116,38 @@ def fetch_priority_batch(db_url: str, batch_size: int = 400) -> list[dict]:
     content_check_count = max(1, int(len(rows) * CONTENT_CHECK_RATIO))
 
     articles = []
+    filtered_count = 0
     for i, row in enumerate(rows):
         integrity = row.integrity or {}
         if isinstance(integrity, str):
             integrity = json.loads(integrity)
 
+        image_url = row.image_url
+        article_url = row.url
+
+        if not _is_allowed_url(image_url):
+            logger.warning(f"image_url filtrada (fora da allowlist): {image_url[:80]}")
+            image_url = None
+            filtered_count += 1
+
+        if not _is_allowed_url(article_url):
+            logger.warning(f"url filtrada (fora da allowlist): {article_url[:80]}")
+            article_url = None
+
         article = {
             "unique_id": row.unique_id,
-            "url": row.url,
-            "image_url": row.image_url,
+            "url": article_url,
+            "image_url": image_url,
             "content_hash": integrity.get("content_hash"),
             "source_etag": integrity.get("source_etag"),
             "check_content": i < content_check_count,
         }
         articles.append(article)
+
+    if filtered_count:
+        logger.warning(
+            f"{filtered_count}/{len(rows)} artigos com image_url filtrada por allowlist"
+        )
 
     logger.info(
         f"Batch de verificação: {len(articles)} artigos "

--- a/tests/unit/jobs/integrity/test_priority.py
+++ b/tests/unit/jobs/integrity/test_priority.py
@@ -1,9 +1,17 @@
 """Testes unitários para priorização de verificação de integridade."""
 
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from data_platform.jobs.integrity.priority import (
+    ALLOWED_URL_PREFIXES,
     CONTENT_CHECK_RATIO,
     PRIORITY_TIERS,
     PRIORITY_QUERY,
+    _is_allowed_url,
+    fetch_priority_batch,
 )
 
 
@@ -79,3 +87,141 @@ class TestContentCheckRatio:
 
     def test_ratio_is_quarter(self):
         assert CONTENT_CHECK_RATIO == 0.25
+
+
+class TestIsAllowedUrl:
+    """Testes para a funcao de validacao de URL."""
+
+    def test_none_is_allowed(self):
+        assert _is_allowed_url(None) is True
+
+    def test_empty_string_is_allowed(self):
+        assert _is_allowed_url("") is True
+
+    def test_gov_br_is_allowed(self):
+        assert _is_allowed_url("https://www.gov.br/mec/pt-br/imagem.jpg") is True
+
+    def test_ebc_is_allowed(self):
+        assert _is_allowed_url("https://agenciabrasil.ebc.com.br/img.jpg") is True
+
+    def test_imagens_ebc_is_allowed(self):
+        assert _is_allowed_url("https://imagens.ebc.com.br/photo.jpg") is True
+
+    def test_staticflickr_is_allowed(self):
+        assert _is_allowed_url("https://live.staticflickr.com/123/img.jpg") is True
+
+    def test_gcs_thumbnails_is_allowed(self):
+        assert _is_allowed_url("https://storage.googleapis.com/destaquesgovbr-thumbnails/x.jpg") is True
+
+    def test_random_domain_is_rejected(self):
+        assert _is_allowed_url("https://cdn.example.com/img.jpg") is False
+
+    def test_http_gov_br_is_rejected(self):
+        assert _is_allowed_url("http://www.gov.br/img.jpg") is False
+
+    def test_gov_br_without_www_is_rejected(self):
+        assert _is_allowed_url("https://gov.br/img.jpg") is False
+
+    def test_other_gcs_bucket_is_rejected(self):
+        assert _is_allowed_url("https://storage.googleapis.com/other-bucket/x.jpg") is False
+
+
+def _make_row(unique_id="art-1", url="https://www.gov.br/mec/noticia",
+              image_url="https://www.gov.br/mec/img.jpg", published_at=None,
+              integrity=None):
+    """Cria um mock de row do SQLAlchemy."""
+    row = MagicMock()
+    row.unique_id = unique_id
+    row.url = url
+    row.image_url = image_url
+    row.published_at = published_at
+    row.integrity = integrity
+    return row
+
+
+@pytest.fixture
+def mock_db():
+    """Mock do engine e conexao SQLAlchemy."""
+    with patch("data_platform.jobs.integrity.priority.create_engine") as mock_engine_cls:
+        mock_engine = MagicMock()
+        mock_engine_cls.return_value = mock_engine
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_conn, mock_engine
+
+
+class TestFetchPriorityBatchUrlFiltering:
+    """Testes para filtragem de URLs fora da allowlist."""
+
+    def test_filters_disallowed_image_url(self, mock_db):
+        mock_conn, _ = mock_db
+        row = _make_row(image_url="https://cdn.example.com/photo.jpg")
+        mock_conn.execute.return_value.fetchall.return_value = [row]
+
+        articles = fetch_priority_batch("postgresql://test", batch_size=10)
+
+        assert len(articles) == 1
+        assert articles[0]["image_url"] is None
+
+    def test_keeps_allowed_image_url(self, mock_db):
+        mock_conn, _ = mock_db
+        expected_url = "https://www.gov.br/mec/pt-br/imagem.jpg"
+        row = _make_row(image_url=expected_url)
+        mock_conn.execute.return_value.fetchall.return_value = [row]
+
+        articles = fetch_priority_batch("postgresql://test", batch_size=10)
+
+        assert articles[0]["image_url"] == expected_url
+
+    def test_none_image_url_stays_none(self, mock_db):
+        mock_conn, _ = mock_db
+        row = _make_row(image_url=None)
+        mock_conn.execute.return_value.fetchall.return_value = [row]
+
+        articles = fetch_priority_batch("postgresql://test", batch_size=10)
+
+        assert articles[0]["image_url"] is None
+
+    def test_logs_filtered_urls(self, mock_db, caplog):
+        mock_conn, _ = mock_db
+        row = _make_row(image_url="https://cdn.example.com/photo.jpg")
+        mock_conn.execute.return_value.fetchall.return_value = [row]
+
+        with caplog.at_level(logging.WARNING):
+            fetch_priority_batch("postgresql://test", batch_size=10)
+
+        assert any("image_url filtrada" in msg for msg in caplog.messages)
+
+    def test_filters_disallowed_article_url(self, mock_db):
+        mock_conn, _ = mock_db
+        row = _make_row(url="https://external-site.org/news/123")
+        mock_conn.execute.return_value.fetchall.return_value = [row]
+
+        articles = fetch_priority_batch("postgresql://test", batch_size=10)
+
+        assert articles[0]["url"] is None
+
+    def test_keeps_allowed_article_url(self, mock_db):
+        mock_conn, _ = mock_db
+        expected_url = "https://www.gov.br/mec/pt-br/noticias/artigo"
+        row = _make_row(url=expected_url)
+        mock_conn.execute.return_value.fetchall.return_value = [row]
+
+        articles = fetch_priority_batch("postgresql://test", batch_size=10)
+
+        assert articles[0]["url"] == expected_url
+
+    def test_summary_log_with_filtered_count(self, mock_db, caplog):
+        mock_conn, _ = mock_db
+        rows = [
+            _make_row(unique_id="a1", image_url="https://cdn.x.com/1.jpg"),
+            _make_row(unique_id="a2", image_url="https://www.gov.br/ok.jpg"),
+            _make_row(unique_id="a3", image_url="https://evil.org/x.jpg"),
+        ]
+        mock_conn.execute.return_value.fetchall.return_value = rows
+
+        with caplog.at_level(logging.WARNING):
+            fetch_priority_batch("postgresql://test", batch_size=10)
+
+        assert any("2/3" in msg and "allowlist" in msg for msg in caplog.messages)


### PR DESCRIPTION
## Contexto

A DAG `verify_news_integrity` falha com 422 porque `fetch_priority_batch()` envia artigos com `image_url` de domínios fora da allowlist SSRF do scraper. A validação Pydantic no endpoint `/verify/integrity` rejeita o **batch inteiro** se qualquer artigo tiver URL inválida.

A migração 013 (PR #158) limpou paths relativos (`resolveuid/...`), mas URLs absolutas de domínios não-allowlistados permaneceram no banco.

## Solução

- `fetch_priority_batch()` agora valida `image_url` e `url` contra `ALLOWED_URL_PREFIXES` antes de montar o payload
- URLs de domínios não-aceitos são tratadas como `None` (artigo sem imagem conhecida)
- Log de warning emitido para cada URL filtrada + resumo do batch (observabilidade)
- Migração 014 para limpar retroativamente URLs inválidas existentes no banco

## Trade-off

A allowlist é duplicada entre scraper (`api.py`) e data-platform (`priority.py`). Isso é intencional: repos independentes com deploy separado. Se divergirem, o impacto é apenas `image_url=None` temporariamente (não falha), e o warning nos logs sinaliza o drift.

## Test plan

- [x] 18 novos testes unitários (11 para `_is_allowed_url`, 7 para `fetch_priority_batch`)
- [x] Suite completa: 524 passed, 0 failed
- [ ] Executar migração 014 (após inspecionar dados com SELECT)
- [ ] Disparar DAG manualmente e verificar sucesso