### PR TITLE
fix: corrigir schema mismatch BigQuery + sistema de migrações BQ

### DIFF
--- a/.github/workflows/bq-migrate.yaml
+++ b/.github/workflows/bq-migrate.yaml
@@ -1,0 +1,102 @@
+name: BigQuery Migration
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: 'Migration command to execute'
+        required: true
+        type: choice
+        options:
+          - status
+          - migrate
+          - history
+          - validate
+      dry_run:
+        description: 'Preview changes without applying (default: true)'
+        required: false
+        type: boolean
+        default: true
+      confirm:
+        description: 'Required for migrate with dry_run=false'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  PROJECT_ID: inspire-7-finep
+
+jobs:
+  validate-inputs:
+    name: Validate Inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check confirmation for destructive operations
+        run: |
+          COMMAND="${{ inputs.command }}"
+          DRY_RUN="${{ inputs.dry_run }}"
+          CONFIRM="${{ inputs.confirm }}"
+
+          echo "## BigQuery Migration Request" >> $GITHUB_STEP_SUMMARY
+          echo "- **Command:** $COMMAND" >> $GITHUB_STEP_SUMMARY
+          echo "- **Dry run:** $DRY_RUN" >> $GITHUB_STEP_SUMMARY
+          echo "- **Confirm:** $CONFIRM" >> $GITHUB_STEP_SUMMARY
+          echo "- **Actor:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$COMMAND" == "migrate" && "$DRY_RUN" == "false" && "$CONFIRM" != "true" ]]; then
+            echo "::error::migrate requires confirm=true when dry_run=false"
+            exit 1
+          fi
+
+  run-migration:
+    name: Run BigQuery Migration
+    needs: validate-inputs
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --only main
+
+      - name: Execute migration command
+        env:
+          GCP_PROJECT_ID: ${{ env.PROJECT_ID }}
+        run: |
+          COMMAND="${{ inputs.command }}"
+          DRY_RUN="${{ inputs.dry_run }}"
+
+          ARGS=("$COMMAND")
+
+          if [[ "$COMMAND" == "migrate" && "$DRY_RUN" == "true" ]]; then
+            ARGS+=(--dry-run)
+          fi
+
+          echo "Executing: python scripts/bq_migrate.py ${ARGS[*]}"
+          echo "## Output" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          poetry run python scripts/bq_migrate.py "${ARGS[@]}" | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/scripts/backfill_bq_20260520.py
+++ b/scripts/backfill_bq_20260520.py
@@ -58,6 +58,7 @@ def main():
     current = start
     total_rows = 0
     skipped = 0
+    failed_dates: list[date] = []
 
     logger.info(f"Backfilling BigQuery fato_noticias: {start} to {end}")
     logger.info(f"Project: {project_id} | Bucket: {bucket}")
@@ -71,19 +72,32 @@ def main():
             current = next_day
             continue
 
-        df = fetch_news_for_bigquery(db_url, str(current), str(next_day))
-        if not df.empty:
-            gcs_uri = write_to_parquet_gcs(df, bucket, str(current))
-            rows = load_parquet_to_bigquery(gcs_uri, project_id)
-            total_rows += rows
-            logger.info(f"  {current}: {rows} rows loaded")
-        else:
-            logger.info(f"  {current}: no data in PG")
+        try:
+            df = fetch_news_for_bigquery(db_url, str(current), str(next_day))
+            if not df.empty:
+                null_hash_count = df["content_hash"].isna().sum()
+                if null_hash_count > 0:
+                    raise ValueError(
+                        f"{null_hash_count}/{len(df)} rows have NULL content_hash"
+                    )
+                gcs_uri = write_to_parquet_gcs(df, bucket, str(current))
+                rows = load_parquet_to_bigquery(gcs_uri, project_id)
+                total_rows += rows
+                logger.info(f"  {current}: {rows} rows loaded")
+            else:
+                logger.info(f"  {current}: no data in PG")
+        except Exception as e:
+            logger.error(f"  {current}: FAILED — {e}")
+            failed_dates.append(current)
+
         current = next_day
 
     logger.info(
         f"Backfill complete: {total_rows} rows loaded, {skipped} days skipped (already existed)"
     )
+    if failed_dates:
+        logger.error(f"FAILED dates (need manual retry): {failed_dates}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/backfill_bq_20260520.py
+++ b/scripts/backfill_bq_20260520.py
@@ -21,6 +21,22 @@ from datetime import date, timedelta
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 logger = logging.getLogger(__name__)
 
+DATASET = "dgb_gold"
+TABLE = "fato_noticias"
+
+
+def date_already_loaded(project_id: str, target_date: date) -> bool:
+    """Check if data for a given date already exists in BigQuery."""
+    from google.cloud import bigquery
+
+    client = bigquery.Client(project=project_id)
+    query = (
+        f"SELECT COUNT(*) as cnt FROM `{project_id}.{DATASET}.{TABLE}` "
+        f"WHERE DATE(published_at) = '{target_date}'"
+    )
+    result = list(client.query(query).result())[0]
+    return result.cnt > 0
+
 
 def main():
     db_url = os.environ.get("DATABASE_URL")
@@ -41,12 +57,20 @@ def main():
     end = date(2026, 5, 20)
     current = start
     total_rows = 0
+    skipped = 0
 
     logger.info(f"Backfilling BigQuery fato_noticias: {start} to {end}")
     logger.info(f"Project: {project_id} | Bucket: {bucket}")
 
     while current < end:
         next_day = current + timedelta(days=1)
+
+        if date_already_loaded(project_id, current):
+            logger.info(f"  {current}: already loaded, skipping")
+            skipped += 1
+            current = next_day
+            continue
+
         df = fetch_news_for_bigquery(db_url, str(current), str(next_day))
         if not df.empty:
             gcs_uri = write_to_parquet_gcs(df, bucket, str(current))
@@ -54,10 +78,12 @@ def main():
             total_rows += rows
             logger.info(f"  {current}: {rows} rows loaded")
         else:
-            logger.info(f"  {current}: no data")
+            logger.info(f"  {current}: no data in PG")
         current = next_day
 
-    logger.info(f"Backfill complete: {total_rows} total rows loaded across {(end - start).days} days")
+    logger.info(
+        f"Backfill complete: {total_rows} rows loaded, {skipped} days skipped (already existed)"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/backfill_bq_20260520.py
+++ b/scripts/backfill_bq_20260520.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+One-time backfill: BigQuery fato_noticias for 2026-05-11 to 2026-05-20.
+
+Backfills 9 days of missed data caused by schema mismatch (content_hash column
+was added to the code but not to the BigQuery table).
+
+Prerequisites:
+  - ALTER TABLE applied (content_hash column exists in BigQuery)
+  - Environment variables: DATABASE_URL, GCP_PROJECT_ID, DATA_LAKE_BUCKET
+
+Usage:
+    DATABASE_URL=... poetry run python scripts/backfill_bq_20260520.py
+"""
+
+import logging
+import os
+import sys
+from datetime import date, timedelta
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main():
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        print("ERROR: DATABASE_URL not set")
+        sys.exit(1)
+
+    project_id = os.environ.get("GCP_PROJECT_ID", "inspire-7-finep")
+    bucket = os.environ.get("DATA_LAKE_BUCKET", "inspire-7-finep-dgb-data-lake")
+
+    from data_platform.jobs.bigquery.sync_to_bigquery import (
+        fetch_news_for_bigquery,
+        load_parquet_to_bigquery,
+        write_to_parquet_gcs,
+    )
+
+    start = date(2026, 5, 11)
+    end = date(2026, 5, 20)
+    current = start
+    total_rows = 0
+
+    logger.info(f"Backfilling BigQuery fato_noticias: {start} to {end}")
+    logger.info(f"Project: {project_id} | Bucket: {bucket}")
+
+    while current < end:
+        next_day = current + timedelta(days=1)
+        df = fetch_news_for_bigquery(db_url, str(current), str(next_day))
+        if not df.empty:
+            gcs_uri = write_to_parquet_gcs(df, bucket, str(current))
+            rows = load_parquet_to_bigquery(gcs_uri, project_id)
+            total_rows += rows
+            logger.info(f"  {current}: {rows} rows loaded")
+        else:
+            logger.info(f"  {current}: no data")
+        current = next_day
+
+    logger.info(f"Backfill complete: {total_rows} total rows loaded across {(end - start).days} days")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bigquery/create_tables.sql
+++ b/scripts/bigquery/create_tables.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS dgb_gold.fato_noticias (
   unique_id STRING NOT NULL,
   title STRING,
   url STRING,
+  content_hash STRING,
 
   -- Agency (denormalized)
   agency_key STRING,

--- a/scripts/bigquery/migrations/001_add_content_hash_to_fato_noticias.sql
+++ b/scripts/bigquery/migrations/001_add_content_hash_to_fato_noticias.sql
@@ -1,0 +1,4 @@
+-- Adds content_hash column to fato_noticias for deduplication tracking.
+-- Ref: PR #153 (deduplicacao por content_hash)
+ALTER TABLE `inspire-7-finep.dgb_gold.fato_noticias`
+ADD COLUMN IF NOT EXISTS content_hash STRING;

--- a/scripts/bigquery/migrations/README.md
+++ b/scripts/bigquery/migrations/README.md
@@ -1,0 +1,40 @@
+# BigQuery Migrations
+
+Forward-only SQL migrations for the `dgb_gold` dataset.
+
+## Convenção
+
+- Arquivo: `NNN_description.sql` (ex: `001_add_content_hash_to_fato_noticias.sql`)
+- Forward-only (sem rollback automático)
+- Usar `IF NOT EXISTS` / `IF EXISTS` para idempotência
+- Referenciar PR/issue no comentário SQL
+
+## Executar
+
+```bash
+# Ver status
+python scripts/bq_migrate.py status
+
+# Aplicar pendentes (dry-run)
+python scripts/bq_migrate.py migrate --dry-run
+
+# Aplicar de verdade
+python scripts/bq_migrate.py migrate
+
+# Histórico
+python scripts/bq_migrate.py history
+
+# Validar arquivos (offline, sem BigQuery)
+python scripts/bq_migrate.py validate
+```
+
+## CI/CD
+
+Workflow manual: `.github/workflows/bq-migrate.yaml`
+
+## Importante
+
+Ao modificar o schema em `sync_to_bigquery.py`, sempre:
+1. Criar migration aqui
+2. Atualizar `create_tables.sql`
+3. Rodar `pytest tests/unit/jobs/bigquery/test_sync_to_bigquery.py::TestSchemaConsistency`

--- a/scripts/bq_migrate.py
+++ b/scripts/bq_migrate.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+BigQuery migration runner for destaquesgovbr/data-platform.
+
+Forward-only SQL migrations for BigQuery tables. Tracks applied migrations
+in a _migration_history table within the dgb_gold dataset.
+
+Usage:
+    python scripts/bq_migrate.py status
+    python scripts/bq_migrate.py migrate [--dry-run]
+    python scripts/bq_migrate.py history
+    python scripts/bq_migrate.py validate
+"""
+
+import argparse
+import getpass
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+MIGRATIONS_DIR = Path(__file__).parent / "bigquery" / "migrations"
+MIGRATION_PATTERN = re.compile(r"^(\d{3})_(.+)\.sql$")
+
+PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "inspire-7-finep")
+DATASET_ID = "dgb_gold"
+HISTORY_TABLE = f"{DATASET_ID}._migration_history"
+
+CREATE_HISTORY_TABLE_SQL = f"""
+CREATE TABLE IF NOT EXISTS `{PROJECT_ID}.{HISTORY_TABLE}` (
+  version STRING NOT NULL,
+  name STRING NOT NULL,
+  status STRING NOT NULL,
+  applied_at TIMESTAMP NOT NULL,
+  applied_by STRING,
+  duration_ms INT64,
+  error_message STRING
+)
+"""
+
+
+def discover_migrations() -> list[dict[str, Any]]:
+    """Discover migration files sorted by version."""
+    migrations = []
+    for f in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        match = MIGRATION_PATTERN.match(f.name)
+        if match:
+            migrations.append({
+                "version": match.group(1),
+                "name": match.group(2),
+                "path": f,
+            })
+    return migrations
+
+
+def get_bigquery_client():
+    """Get authenticated BigQuery client."""
+    from google.cloud import bigquery
+    return bigquery.Client(project=PROJECT_ID)
+
+
+def ensure_history_table(client) -> None:
+    """Create migration history table if it doesn't exist."""
+    client.query(CREATE_HISTORY_TABLE_SQL).result()
+
+
+def get_applied_versions(client) -> set[str]:
+    """Get set of successfully applied migration versions."""
+    query = f"SELECT DISTINCT version FROM `{PROJECT_ID}.{HISTORY_TABLE}` WHERE status = 'success'"
+    try:
+        rows = client.query(query).result()
+        return {row.version for row in rows}
+    except Exception:
+        return set()
+
+
+def record_migration(client, version: str, name: str, status: str,
+                     duration_ms: int, error_message: str | None = None) -> None:
+    """Record migration execution in history table."""
+    query = f"""
+    INSERT INTO `{PROJECT_ID}.{HISTORY_TABLE}`
+    (version, name, status, applied_at, applied_by, duration_ms, error_message)
+    VALUES (@version, @name, @status, @applied_at, @applied_by, @duration_ms, @error_message)
+    """
+    from google.cloud import bigquery
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("version", "STRING", version),
+            bigquery.ScalarQueryParameter("name", "STRING", name),
+            bigquery.ScalarQueryParameter("status", "STRING", status),
+            bigquery.ScalarQueryParameter("applied_at", "TIMESTAMP",
+                                          datetime.now(timezone.utc).isoformat()),
+            bigquery.ScalarQueryParameter("applied_by", "STRING", getpass.getuser()),
+            bigquery.ScalarQueryParameter("duration_ms", "INT64", duration_ms),
+            bigquery.ScalarQueryParameter("error_message", "STRING", error_message),
+        ]
+    )
+    client.query(query, job_config=job_config).result()
+
+
+def cmd_status(client) -> None:
+    """Show pending and applied migrations."""
+    ensure_history_table(client)
+    applied = get_applied_versions(client)
+    migrations = discover_migrations()
+
+    print(f"BigQuery Migrations — {PROJECT_ID}.{DATASET_ID}")
+    print(f"{'=' * 60}")
+    print()
+
+    pending = []
+    for m in migrations:
+        status = "applied" if m["version"] in applied else "PENDING"
+        marker = "  " if status == "applied" else ">>"
+        print(f"  {marker} [{m['version']}] {m['name']} — {status}")
+        if status == "PENDING":
+            pending.append(m)
+
+    print()
+    if pending:
+        print(f"{len(pending)} pending migration(s)")
+    else:
+        print("All migrations applied.")
+
+
+def cmd_migrate(client, dry_run: bool = False) -> None:
+    """Apply pending migrations."""
+    ensure_history_table(client)
+    applied = get_applied_versions(client)
+    migrations = discover_migrations()
+
+    pending = [m for m in migrations if m["version"] not in applied]
+    if not pending:
+        print("No pending migrations.")
+        return
+
+    print(f"{'[DRY RUN] ' if dry_run else ''}Applying {len(pending)} migration(s):\n")
+
+    for m in pending:
+        sql = m["path"].read_text()
+        print(f"  [{m['version']}] {m['name']}")
+
+        if dry_run:
+            print(f"    SQL: {sql.strip()[:100]}...")
+            print("    (skipped — dry run)")
+            continue
+
+        start = time.time()
+        try:
+            client.query(sql).result()
+            duration_ms = int((time.time() - start) * 1000)
+            record_migration(client, m["version"], m["name"], "success", duration_ms)
+            print(f"    Applied ({duration_ms}ms)")
+        except Exception as e:
+            duration_ms = int((time.time() - start) * 1000)
+            record_migration(client, m["version"], m["name"], "failed", duration_ms, str(e))
+            print(f"    FAILED: {e}")
+            sys.exit(1)
+
+    print(f"\n{'[DRY RUN] ' if dry_run else ''}Done.")
+
+
+def cmd_history(client) -> None:
+    """Show migration history."""
+    ensure_history_table(client)
+    query = f"""
+    SELECT version, name, status, applied_at, applied_by, duration_ms
+    FROM `{PROJECT_ID}.{HISTORY_TABLE}`
+    ORDER BY applied_at DESC
+    LIMIT 20
+    """
+    rows = list(client.query(query).result())
+    if not rows:
+        print("No migration history.")
+        return
+
+    print(f"{'Version':<8} {'Name':<40} {'Status':<8} {'Applied At':<20} {'By':<10} {'ms'}")
+    print("-" * 100)
+    for row in rows:
+        print(
+            f"{row.version:<8} {row.name:<40} {row.status:<8} "
+            f"{row.applied_at.strftime('%Y-%m-%d %H:%M'):<20} "
+            f"{(row.applied_by or ''):<10} {row.duration_ms or ''}"
+        )
+
+
+def cmd_validate() -> None:
+    """Validate migration files without connecting to BigQuery."""
+    migrations = discover_migrations()
+    errors = []
+
+    for m in migrations:
+        sql = m["path"].read_text()
+        if not sql.strip():
+            errors.append(f"[{m['version']}] Empty migration file")
+        if "DROP TABLE" in sql.upper() and "IF EXISTS" not in sql.upper():
+            errors.append(f"[{m['version']}] DROP TABLE without IF EXISTS")
+
+    if errors:
+        print("Validation FAILED:")
+        for e in errors:
+            print(f"  - {e}")
+        sys.exit(1)
+
+    print(f"Validated {len(migrations)} migration(s) — all OK.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="BigQuery migration runner")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("status", help="Show migration status")
+
+    migrate_parser = subparsers.add_parser("migrate", help="Apply pending migrations")
+    migrate_parser.add_argument("--dry-run", action="store_true", help="Preview without applying")
+
+    subparsers.add_parser("history", help="Show migration history")
+    subparsers.add_parser("validate", help="Validate migration files (offline)")
+
+    args = parser.parse_args()
+
+    if args.command == "validate":
+        cmd_validate()
+        return
+
+    client = get_bigquery_client()
+
+    if args.command == "status":
+        cmd_status(client)
+    elif args.command == "migrate":
+        cmd_migrate(client, dry_run=args.dry_run)
+    elif args.command == "history":
+        cmd_history(client)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bq_migrate.py
+++ b/scripts/bq_migrate.py
@@ -152,11 +152,17 @@ def cmd_migrate(client, dry_run: bool = False) -> None:
         try:
             client.query(sql).result()
             duration_ms = int((time.time() - start) * 1000)
-            record_migration(client, m["version"], m["name"], "success", duration_ms)
+            try:
+                record_migration(client, m["version"], m["name"], "success", duration_ms)
+            except Exception as record_err:
+                print(f"    WARNING: Migration applied but failed to record: {record_err}")
             print(f"    Applied ({duration_ms}ms)")
         except Exception as e:
             duration_ms = int((time.time() - start) * 1000)
-            record_migration(client, m["version"], m["name"], "failed", duration_ms, str(e))
+            try:
+                record_migration(client, m["version"], m["name"], "failed", duration_ms, str(e))
+            except Exception:
+                pass
             print(f"    FAILED: {e}")
             sys.exit(1)
 

--- a/tests/integration/test_bq_migrate_integration.py
+++ b/tests/integration/test_bq_migrate_integration.py
@@ -1,0 +1,148 @@
+"""
+Integration tests for BigQuery migration runner.
+
+These tests require GCP authentication and BigQuery access.
+Run with: pytest tests/integration/test_bq_migrate_integration.py -v
+
+They validate that:
+- Migration SQL is syntactically valid against BigQuery
+- The history table can be created and queried
+- The migrate command applies migrations idempotently
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+BQ_MIGRATE_SCRIPT = Path(__file__).parents[2] / "scripts" / "bq_migrate.py"
+PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "inspire-7-finep")
+
+
+def _load_bq_migrate():
+    spec = importlib.util.spec_from_file_location("bq_migrate", BQ_MIGRATE_SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _get_bq_client():
+    from google.cloud import bigquery
+
+    return bigquery.Client(project=PROJECT_ID)
+
+
+@pytest.mark.integration
+class TestBqMigrateOffline:
+    """Tests that validate migration files without BigQuery access."""
+
+    def test_validate_command_passes(self):
+        """All migration files pass offline validation."""
+        mod = _load_bq_migrate()
+        mod.cmd_validate()
+
+    def test_all_migrations_use_idempotent_ddl(self):
+        """Migrations should use IF NOT EXISTS / IF EXISTS for safety."""
+        mod = _load_bq_migrate()
+        migrations = mod.discover_migrations()
+
+        for m in migrations:
+            sql = m["path"].read_text().upper()
+            has_alter = "ALTER TABLE" in sql
+            has_create = "CREATE TABLE" in sql
+            has_drop = "DROP" in sql
+
+            if has_alter and "ADD COLUMN" in sql:
+                assert "IF NOT EXISTS" in sql, (
+                    f"Migration {m['version']}: ALTER TABLE ADD COLUMN should use IF NOT EXISTS"
+                )
+            if has_create:
+                assert "IF NOT EXISTS" in sql, (
+                    f"Migration {m['version']}: CREATE TABLE should use IF NOT EXISTS"
+                )
+            if has_drop:
+                assert "IF EXISTS" in sql, (
+                    f"Migration {m['version']}: DROP should use IF EXISTS"
+                )
+
+
+@pytest.mark.integration
+class TestBqMigrateIntegration:
+    """Integration tests that hit BigQuery."""
+
+    @pytest.fixture(autouse=True)
+    def _require_bigquery(self):
+        """Skip all tests if BigQuery is not accessible."""
+        try:
+            client = _get_bq_client()
+            client.query("SELECT 1").result()
+        except Exception as e:
+            pytest.skip(f"BigQuery not accessible: {e}")
+
+    def test_history_table_creation(self):
+        """ensure_history_table creates _migration_history without error."""
+        mod = _load_bq_migrate()
+        client = _get_bq_client()
+        mod.ensure_history_table(client)
+
+        query = f"SELECT COUNT(*) as cnt FROM `{PROJECT_ID}.dgb_gold._migration_history`"
+        result = list(client.query(query).result())[0]
+        assert result.cnt >= 0
+
+    def test_get_applied_versions_returns_set(self):
+        """get_applied_versions returns a set (possibly empty)."""
+        mod = _load_bq_migrate()
+        client = _get_bq_client()
+        mod.ensure_history_table(client)
+
+        versions = mod.get_applied_versions(client)
+        assert isinstance(versions, set)
+
+    def test_migration_sql_is_valid_via_dry_run(self):
+        """Each migration file contains valid BigQuery SQL (dry-run validation)."""
+        mod = _load_bq_migrate()
+        client = _get_bq_client()
+        from google.cloud import bigquery
+
+        migrations = mod.discover_migrations()
+        assert len(migrations) >= 1
+
+        for m in migrations:
+            sql = m["path"].read_text()
+            job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)
+            try:
+                client.query(sql, job_config=job_config)
+            except Exception as e:
+                error_str = str(e)
+                if "Syntax error" in error_str:
+                    pytest.fail(f"Migration {m['version']} has syntax error: {e}")
+
+    def test_migrate_is_idempotent(self):
+        """Running migrate twice does not fail or duplicate history entries."""
+        mod = _load_bq_migrate()
+        client = _get_bq_client()
+        mod.ensure_history_table(client)
+
+        mod.cmd_migrate(client, dry_run=False)
+
+        query = (
+            f"SELECT COUNT(*) as cnt FROM `{PROJECT_ID}.dgb_gold._migration_history` "
+            f"WHERE status = 'success'"
+        )
+        count_after_first = list(client.query(query).result())[0].cnt
+
+        mod.cmd_migrate(client, dry_run=False)
+
+        count_after_second = list(client.query(query).result())[0].cnt
+        assert count_after_second == count_after_first
+
+    def test_status_command_runs(self, capsys):
+        """status command runs without error."""
+        mod = _load_bq_migrate()
+        client = _get_bq_client()
+        mod.ensure_history_table(client)
+        mod.cmd_status(client)
+
+        captured = capsys.readouterr()
+        assert "BigQuery Migrations" in captured.out

--- a/tests/unit/jobs/bigquery/test_sync_to_bigquery.py
+++ b/tests/unit/jobs/bigquery/test_sync_to_bigquery.py
@@ -72,6 +72,71 @@ class TestFetchNewsForBigquery:
         assert "2024-06-02" in call_params
 
 
+class TestSchemaConsistency:
+    """Ensure BigQuery schema in code stays in sync with create_tables.sql."""
+
+    def test_load_schema_matches_create_tables_ddl(self):
+        """LoadJobConfig schema fields must match fato_noticias DDL columns."""
+        import inspect
+        import re
+        from pathlib import Path
+
+        from data_platform.jobs.bigquery.sync_to_bigquery import load_parquet_to_bigquery
+
+        source = inspect.getsource(load_parquet_to_bigquery)
+        code_columns = re.findall(r'SchemaField\("(\w+)"', source)
+
+        ddl_path = Path(__file__).parents[4] / "scripts" / "bigquery" / "create_tables.sql"
+        ddl_text = ddl_path.read_text()
+        match = re.search(
+            r"CREATE TABLE.*?fato_noticias\s*\((.*?)\)\s*PARTITION BY",
+            ddl_text,
+            re.DOTALL | re.IGNORECASE,
+        )
+        assert match, "Could not parse fato_noticias from create_tables.sql"
+        ddl_columns = re.findall(r"^\s*(\w+)\s+\w+", match.group(1), re.MULTILINE)
+
+        assert code_columns == ddl_columns, (
+            f"Schema mismatch between code and DDL!\n"
+            f"Code ({len(code_columns)}): {code_columns}\n"
+            f"DDL  ({len(ddl_columns)}): {ddl_columns}"
+        )
+
+    def test_sync_query_columns_match_load_schema(self):
+        """SYNC_QUERY SELECT aliases must match LoadJobConfig schema fields."""
+        import inspect
+        import re
+
+        from data_platform.jobs.bigquery.sync_to_bigquery import (
+            SYNC_QUERY,
+            load_parquet_to_bigquery,
+        )
+
+        select_match = re.search(r"SELECT\s+(.*?)\s+FROM\s+news", SYNC_QUERY, re.DOTALL)
+        assert select_match, "Could not parse SELECT from SYNC_QUERY"
+        query_columns = []
+        for line in select_match.group(1).split(","):
+            line = line.strip()
+            if not line:
+                continue
+            as_match = re.search(r"\bAS\s+(\w+)\s*$", line, re.IGNORECASE)
+            if as_match:
+                query_columns.append(as_match.group(1))
+            else:
+                col_match = re.search(r"\.?(\w+)\s*$", line)
+                if col_match:
+                    query_columns.append(col_match.group(1))
+
+        source = inspect.getsource(load_parquet_to_bigquery)
+        schema_columns = re.findall(r'SchemaField\("(\w+)"', source)
+
+        assert query_columns == schema_columns, (
+            f"SYNC_QUERY columns don't match LoadJobConfig schema!\n"
+            f"Query  ({len(query_columns)}): {query_columns}\n"
+            f"Schema ({len(schema_columns)}): {schema_columns}"
+        )
+
+
 class TestDagStructure:
     """Tests for the DAG definition — only runs when Airflow is available."""
 

--- a/tests/unit/test_bq_migrate.py
+++ b/tests/unit/test_bq_migrate.py
@@ -1,0 +1,73 @@
+"""Unit tests for BigQuery migration runner."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+MIGRATIONS_DIR = Path(__file__).parents[2] / "scripts" / "bigquery" / "migrations"
+BQ_MIGRATE_SCRIPT = Path(__file__).parents[2] / "scripts" / "bq_migrate.py"
+
+
+class TestMigrationDiscovery:
+    """Tests for discovering and parsing migration files."""
+
+    def test_migrations_dir_exists(self):
+        assert MIGRATIONS_DIR.is_dir()
+
+    def test_first_migration_exists(self):
+        first = MIGRATIONS_DIR / "001_add_content_hash_to_fato_noticias.sql"
+        assert first.is_file()
+
+    def test_migration_files_follow_naming_convention(self):
+        pattern = re.compile(r"^\d{3}_[a-z0-9_]+\.sql$")
+        for f in MIGRATIONS_DIR.glob("*.sql"):
+            assert pattern.match(f.name), f"Invalid migration name: {f.name}"
+
+    def test_migration_files_are_valid_sql(self):
+        for f in MIGRATIONS_DIR.glob("*.sql"):
+            content = f.read_text()
+            assert len(content.strip()) > 0, f"Empty migration: {f.name}"
+            assert ";" in content or content.strip().endswith("STRING"), (
+                f"Migration missing statement terminator: {f.name}"
+            )
+
+
+class TestBqMigrateModule:
+    """Tests for bq_migrate.py module."""
+
+    def test_script_exists(self):
+        assert BQ_MIGRATE_SCRIPT.is_file()
+
+    def test_can_import_discover_migrations(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("bq_migrate", BQ_MIGRATE_SCRIPT)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        assert hasattr(mod, "discover_migrations")
+
+    def test_discover_migrations_returns_sorted_list(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("bq_migrate", BQ_MIGRATE_SCRIPT)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        migrations = mod.discover_migrations()
+        assert len(migrations) >= 1
+        assert migrations[0]["version"] == "001"
+        assert "content_hash" in migrations[0]["name"]
+        assert migrations[0]["path"].exists()
+
+    def test_discover_migrations_sorted_by_version(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("bq_migrate", BQ_MIGRATE_SCRIPT)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        migrations = mod.discover_migrations()
+        versions = [m["version"] for m in migrations]
+        assert versions == sorted(versions)


### PR DESCRIPTION
## Summary

- A DAG `sync_pg_to_bigquery` falha desde 12/05/2026 (9 dias) com erro `Cannot add fields (field: content_hash)`
- **Causa raiz**: PR #153 adicionou `content_hash` ao código mas a tabela BigQuery nunca recebeu ALTER TABLE
- Este PR corrige o DDL, adiciona testes preventivos, e cria um sistema de migrações BigQuery

## Mudanças

- `scripts/bigquery/create_tables.sql` — adiciona coluna `content_hash`
- `tests/unit/jobs/bigquery/test_sync_to_bigquery.py` — testes de consistência schema (code vs DDL, query vs schema)
- `scripts/bq_migrate.py` — migration runner BigQuery (status, migrate, history, validate)
- `scripts/bigquery/migrations/001_add_content_hash_to_fato_noticias.sql` — primeira migração
- `.github/workflows/bq-migrate.yaml` — workflow CI/CD para migrações BQ
- `scripts/backfill_bq_20260520.py` — script one-shot para reprocessar 9 dias perdidos
- `tests/unit/test_bq_migrate.py` — testes do migration runner

## Passos pós-merge

1. Executar workflow `bq-migrate.yaml` (command=migrate, dry_run=false, confirm=true)
2. Executar `backfill_bq_20260520.py` com credenciais de produção
3. Verificar próxima execução automática da DAG

## Test plan

- [x] `pytest tests/unit/jobs/bigquery/ tests/unit/test_bq_migrate.py` — 71 passed, 0 failed
- [ ] Workflow `bq-migrate.yaml` aplica migração com sucesso
- [ ] DAG `sync_pg_to_bigquery` executa com sucesso após migração
- [ ] Dados de 11 a 19 de maio presentes no BigQuery após backfill