### PR TITLE
fix: aplicar ALTER TABLE content_hash via task ensure_schema no Airflow

### DIFF
--- a/src/data_platform/dags/sync_pg_to_bigquery.py
+++ b/src/data_platform/dags/sync_pg_to_bigquery.py
@@ -43,6 +43,28 @@ logger = logging.getLogger(__name__)
 def sync_pg_to_bigquery():
 
     @task
+    def ensure_schema(**context):
+        """Apply pending BigQuery schema migrations before syncing.
+
+        Runs ALTER TABLE ... ADD COLUMN IF NOT EXISTS for each pending migration.
+        Idempotent — safe to re-run even if columns already exist.
+        """
+        from google.cloud import bigquery
+
+        project_id = Variable.get("gcp_project_id", default_var="inspire-7-finep")
+        client = bigquery.Client(project=project_id)
+
+        migrations = [
+            f"ALTER TABLE `{project_id}.dgb_gold.fato_noticias` ADD COLUMN IF NOT EXISTS content_hash STRING",
+        ]
+
+        for sql in migrations:
+            client.query(sql).result()
+            logger.info(f"Schema migration applied: {sql[:80]}...")
+
+        return {"status": "success", "migrations": len(migrations)}
+
+    @task
     def sync_facts(**context):
         """Query PG for previous day's news + features, load into BigQuery."""
         from data_platform.jobs.bigquery.sync_to_bigquery import (
@@ -92,8 +114,9 @@ def sync_pg_to_bigquery():
         sync_dimensions(db_url, project_id)
         return {"status": "success"}
 
-    # Tasks run in parallel (no dependency between facts and dims)
-    sync_facts()
+    # ensure_schema runs first, then facts and dims in parallel
+    schema = ensure_schema()
+    sync_facts(schema)
     sync_dims()
 
 

--- a/src/data_platform/dags/sync_pg_to_bigquery.py
+++ b/src/data_platform/dags/sync_pg_to_bigquery.py
@@ -43,26 +43,30 @@ logger = logging.getLogger(__name__)
 def sync_pg_to_bigquery():
 
     @task
-    def ensure_schema(**context):
-        """Apply pending BigQuery schema migrations before syncing.
+    def ensure_schema(**context) -> dict[str, str]:
+        """Workaround: apply ALTER TABLE via Airflow SA (bq-migrate.yaml SA lacks permissions).
 
-        Runs ALTER TABLE ... ADD COLUMN IF NOT EXISTS for each pending migration.
-        Idempotent — safe to re-run even if columns already exist.
+        Remove this task once bq-migrate.yaml has bigquery.jobs.create permission.
         """
         from google.cloud import bigquery
+        from google.cloud.exceptions import Forbidden
 
         project_id = Variable.get("gcp_project_id", default_var="inspire-7-finep")
         client = bigquery.Client(project=project_id)
 
-        migrations = [
-            f"ALTER TABLE `{project_id}.dgb_gold.fato_noticias` ADD COLUMN IF NOT EXISTS content_hash STRING",
-        ]
+        sql = (
+            f"ALTER TABLE `{project_id}.dgb_gold.fato_noticias` "
+            f"ADD COLUMN IF NOT EXISTS content_hash STRING"
+        )
 
-        for sql in migrations:
+        try:
             client.query(sql).result()
-            logger.info(f"Schema migration applied: {sql[:80]}...")
+            logger.info("ensure_schema: content_hash column ensured")
+        except Forbidden as e:
+            logger.error(f"ensure_schema: permission denied — {e}")
+            raise
 
-        return {"status": "success", "migrations": len(migrations)}
+        return {"status": "success"}
 
     @task
     def sync_facts(**context):
@@ -116,8 +120,7 @@ def sync_pg_to_bigquery():
 
     # ensure_schema runs first, then facts and dims in parallel
     schema = ensure_schema()
-    sync_facts(schema)
-    sync_dims()
+    schema >> [sync_facts(), sync_dims()]
 
 
 dag_instance = sync_pg_to_bigquery()


### PR DESCRIPTION
## Problema

O workflow `bq-migrate.yaml` falhou silenciosamente ao tentar aplicar `ALTER TABLE` no BigQuery: a service account do GitHub Actions não tem `bigquery.jobs.create`. A coluna `content_hash` nunca foi adicionada à tabela `fato_noticias`, e a DAG `sync_pg_to_bigquery` está falhando há 10 dias.

## Solução

Adiciona task `ensure_schema` na DAG, que roda **antes** de `sync_facts` e `sync_dims` usando a SA do Airflow (Composer) — que já tem acesso ao BigQuery (confirmado: `sync_dims` funciona).

```
ensure_schema → sync_facts
             ↘ sync_dims
```

`ensure_schema` executa `ADD COLUMN IF NOT EXISTS content_hash STRING` — idempotente, sem efeito após a primeira execução bem-sucedida.

## Após merge

Re-executar os 8 runs falhados (2026-05-12 a 2026-05-19) via clear de task instances.