### PR TITLE
feat: pre-flight check, testes de integracao e docs para migrations (#133)

### DIFF
--- a/.github/workflows/ci-migrations.yaml
+++ b/.github/workflows/ci-migrations.yaml
@@ -1,0 +1,54 @@
+name: Migration Integration Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/migrate.py'
+      - 'scripts/migrations/**'
+      - 'tests/integration/test_migrate_integration.py'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/migrate.py'
+      - 'scripts/migrations/**'
+
+jobs:
+  test-migrations:
+    name: Test Migrations (PostgreSQL)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test_migrations
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Run migration integration tests
+        env:
+          MIGRATION_TEST_DATABASE_URL: postgresql://test:test@localhost:5432/test_migrations
+        run: poetry run pytest tests/integration/test_migrate_integration.py -v --tb=short

--- a/.github/workflows/db-migrate.yaml
+++ b/.github/workflows/db-migrate.yaml
@@ -187,6 +187,32 @@ jobs:
           fi
           echo "Cloud SQL Proxy started successfully"
 
+      - name: Pre-flight migration status
+        if: inputs.command == 'migrate'
+        continue-on-error: true
+        env:
+          DATABASE_URL: ${{ steps.db.outputs.url }}
+        run: |
+          LOCAL_URL=$(echo "$DATABASE_URL" | sed -E 's|@[^:]+:|@127.0.0.1:|')
+          echo "::add-mask::$LOCAL_URL"
+
+          echo "## Pre-flight: Pending Migrations" >> $GITHUB_STEP_SUMMARY
+
+          STATUS_OUTPUT=$(poetry run python scripts/migrate.py status --db-url "$LOCAL_URL" 2>&1) || true
+          echo "$STATUS_OUTPUT"
+
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "$STATUS_OUTPUT" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          PENDING_COUNT=$(echo "$STATUS_OUTPUT" | grep -c "PENDING" || true)
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Pending: ${PENDING_COUNT} migration(s)**" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$PENDING_COUNT" -gt 3 ] && [ "${{ inputs.dry_run }}" = "false" ]; then
+            echo "::warning::High pending migration count (${PENDING_COUNT}). Verify migration_history is intact before proceeding."
+          fi
+
       - name: Execute migration command
         env:
           DATABASE_URL: ${{ steps.db.outputs.url }}

--- a/docs/database/migrations.md
+++ b/docs/database/migrations.md
@@ -164,6 +164,89 @@ The `db-migrate.yaml` workflow runs migrations via GitHub Actions with:
 
 ---
 
+## Stamp Command
+
+The `stamp` command marks migrations as applied **without executing them**. Use it when migrations were already applied outside of the runner.
+
+### When to Use
+
+| Scenario | Example |
+|----------|---------|
+| Existing DB before the runner was introduced | Migrations 001-007 were applied by a previous workflow that didn't record history |
+| Restored from backup | Backup has schema changes but `migration_history` was truncated or absent |
+| Staging from production snapshot | Clone production DB for testing — schema is current, history may differ |
+
+### Usage
+
+```bash
+# Via CLI (local)
+python scripts/migrate.py stamp 007 --yes --db-url "$DATABASE_URL"
+
+# Via GitHub Actions workflow
+# Inputs: command=stamp, target_version=007, confirm=true
+```
+
+### How It Differs from Migrate
+
+| | `migrate` | `stamp` |
+|-|-----------|---------|
+| Executes SQL/Python | Yes | No |
+| Records in `migration_history` | Yes (operation=migrate) | Yes (operation=migrate, description=stamped) |
+| Requires confirmation | Yes (dry_run=false) | Always |
+| Use case | Normal deployment | Bootstrap existing databases |
+
+### Important
+
+- `stamp` bypasses all safety checks — incorrect use can cause schema drift
+- Always run `status` first to verify which migrations will be stamped
+- After stamping, run `validate` to confirm consistency
+
+---
+
+## Idempotency Convention
+
+All SQL migrations MUST be safe to re-execute. This prevents cascading failures when `migration_history` gets out of sync with actual schema state.
+
+### Patterns
+
+| Operation | Idempotent Pattern |
+|-----------|--------------------|
+| Create table | `CREATE TABLE IF NOT EXISTS` |
+| Create index | `CREATE INDEX IF NOT EXISTS` |
+| Add column | `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` |
+| Create/replace function | `CREATE OR REPLACE FUNCTION` |
+| Create/replace view | `CREATE OR REPLACE VIEW` |
+| Create/replace trigger | `CREATE OR REPLACE TRIGGER` |
+| Alter column type | `DO $$ BEGIN IF EXISTS (SELECT ... WHERE character_maximum_length < N) THEN ALTER ... END IF; END $$` |
+| Insert reference data | `INSERT ... ON CONFLICT DO NOTHING` |
+| Update data | Use WHERE clauses that make repeated execution a no-op |
+
+### PostgreSQL Limitations
+
+`ALTER COLUMN TYPE` has no `IF NOT EXISTS` equivalent. Use a conditional block:
+
+```sql
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'news' AND column_name = 'unique_id'
+      AND character_maximum_length < 120
+  ) THEN
+    ALTER TABLE news ALTER COLUMN unique_id TYPE VARCHAR(120);
+  END IF;
+END $$;
+```
+
+### Code Review Checklist
+
+When reviewing a PR that adds or modifies migrations:
+
+1. Every DDL statement uses `IF NOT EXISTS` / `CREATE OR REPLACE`
+2. Data mutations (UPDATE/INSERT) have WHERE clauses that make them no-ops on re-run
+3. If the migration ran twice by accident, would it produce the same end state?
+
+---
+
 See also:
 - [Database Schema](./schema.md)
 - [Migration Rollback Runbook](../runbooks/migration-rollback.md)

--- a/tests/integration/test_migrate_integration.py
+++ b/tests/integration/test_migrate_integration.py
@@ -146,18 +146,19 @@ def _reset_database():
     """Drop and recreate the test database schema."""
     conn = psycopg2.connect(DATABASE_URL)
     conn.autocommit = True
-    cur = conn.cursor()
-    cur.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
-    cur.close()
-    conn.close()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
+    finally:
+        conn.close()
 
     conn = psycopg2.connect(DATABASE_URL)
-    conn.autocommit = False
-    cur = conn.cursor()
-    cur.execute(BASELINE_SQL)
-    conn.commit()
-    cur.close()
-    conn.close()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(BASELINE_SQL)
+        conn.commit()
+    finally:
+        conn.close()
 
 
 @pytest.fixture(autouse=True)
@@ -168,7 +169,12 @@ def fresh_database():
 
 
 def _apply_all_migrations():
-    """Apply all migrations, handling CONCURRENTLY ones specially."""
+    """Apply all migrations in 3 phases to handle CONCURRENTLY limitations.
+
+    Phase 1: Apply migrations up to the first CONCURRENTLY one via runner.
+    Phase 2: Apply each CONCURRENTLY migration manually (outside transaction) + stamp.
+    Phase 3: Apply remaining migrations via runner.
+    """
     if not CONCURRENT_MIGRATIONS:
         result = _run_migrate("migrate", "--yes")
         assert result.returncode == 0, f"Migration failed:\n{result.stdout}\n{result.stderr}"

--- a/tests/integration/test_migrate_integration.py
+++ b/tests/integration/test_migrate_integration.py
@@ -1,0 +1,283 @@
+"""
+Integration tests for the database migration system.
+
+Validates that all migrations can run sequentially against a real PostgreSQL
+database, are idempotent (safe to re-execute), and support rollback.
+
+Requires: PostgreSQL with pgvector extension (docker compose up).
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+MIGRATE_SCRIPT = SCRIPTS_DIR / "migrate.py"
+MIGRATIONS_DIR = SCRIPTS_DIR / "migrations"
+
+DATABASE_URL = os.getenv(
+    "MIGRATION_TEST_DATABASE_URL",
+    "postgresql://test:test@localhost:5432/test_migrations",
+)
+
+
+def _find_concurrent_migrations() -> set[str]:
+    """Detect migrations that use CONCURRENTLY (incompatible with transactions)."""
+    versions = set()
+    for f in MIGRATIONS_DIR.glob("[0-9][0-9][0-9]_*.sql"):
+        if "_rollback" in f.name:
+            continue
+        content = f.read_text()
+        if "CONCURRENTLY" in content:
+            versions.add(f.name[:3])
+    return versions
+
+
+# Migrations that use CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+# The runner wraps each migration in a transaction, so these must be applied manually.
+CONCURRENT_MIGRATIONS = _find_concurrent_migrations()
+
+BASELINE_SQL = """
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS agencies (
+    id SERIAL PRIMARY KEY,
+    key VARCHAR(100) UNIQUE NOT NULL,
+    name VARCHAR(500) NOT NULL,
+    type VARCHAR(100),
+    parent_key VARCHAR(100),
+    url TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS themes (
+    id SERIAL PRIMARY KEY,
+    code VARCHAR(20) UNIQUE NOT NULL,
+    label VARCHAR(500) NOT NULL,
+    full_name VARCHAR(600),
+    level SMALLINT NOT NULL CHECK (level IN (1, 2, 3)),
+    parent_code VARCHAR(20),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS news (
+    id SERIAL PRIMARY KEY,
+    unique_id VARCHAR(32) UNIQUE NOT NULL,
+    agency_id INTEGER NOT NULL REFERENCES agencies(id),
+    theme_l1_id INTEGER REFERENCES themes(id),
+    theme_l2_id INTEGER REFERENCES themes(id),
+    theme_l3_id INTEGER REFERENCES themes(id),
+    most_specific_theme_id INTEGER REFERENCES themes(id),
+    title TEXT NOT NULL,
+    url TEXT,
+    image_url TEXT,
+    video_url TEXT,
+    category VARCHAR(500),
+    tags TEXT[],
+    content TEXT,
+    editorial_lead TEXT,
+    subtitle TEXT,
+    summary TEXT,
+    published_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_datetime TIMESTAMP WITH TIME ZONE,
+    extracted_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    agency_key VARCHAR(100),
+    agency_name VARCHAR(500)
+);
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_news_updated_at
+    BEFORE UPDATE ON news
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+CREATE INDEX IF NOT EXISTS idx_news_unique_id ON news(unique_id);
+CREATE INDEX IF NOT EXISTS idx_news_published_at ON news(published_at DESC);
+CREATE INDEX IF NOT EXISTS idx_news_agency_id ON news(agency_id);
+CREATE INDEX IF NOT EXISTS idx_news_agency_key ON news(agency_key);
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version VARCHAR(20) PRIMARY KEY,
+    description TEXT,
+    applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+"""
+
+
+def _run_migrate(*args: str, needs_db: bool = True) -> subprocess.CompletedProcess:
+    """Run the migrate.py script with given arguments."""
+    cmd = [sys.executable, str(MIGRATE_SCRIPT), *args]
+    if needs_db:
+        cmd.extend(["--db-url", DATABASE_URL])
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+
+
+def _apply_concurrent_migration(version: str):
+    """Apply a CONCURRENTLY migration outside a transaction, then stamp it."""
+    migration_file = next(MIGRATIONS_DIR.glob(f"{version}_*.sql"))
+    sql = migration_file.read_text()
+    # Remove CONCURRENTLY keyword so it can run in normal mode for testing
+    sql_without_concurrent = sql.replace(" CONCURRENTLY", "")
+
+    conn = psycopg2.connect(DATABASE_URL)
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute(sql_without_concurrent)
+    cur.close()
+    conn.close()
+
+    _run_migrate("stamp", version, "--yes")
+
+
+def _reset_database():
+    """Drop and recreate the test database schema."""
+    conn = psycopg2.connect(DATABASE_URL)
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
+    cur.close()
+    conn.close()
+
+    conn = psycopg2.connect(DATABASE_URL)
+    conn.autocommit = False
+    cur = conn.cursor()
+    cur.execute(BASELINE_SQL)
+    conn.commit()
+    cur.close()
+    conn.close()
+
+
+@pytest.fixture(autouse=True)
+def fresh_database():
+    """Reset database to baseline state before each test."""
+    _reset_database()
+    yield
+
+
+def _apply_all_migrations():
+    """Apply all migrations, handling CONCURRENTLY ones specially."""
+    if not CONCURRENT_MIGRATIONS:
+        result = _run_migrate("migrate", "--yes")
+        assert result.returncode == 0, f"Migration failed:\n{result.stdout}\n{result.stderr}"
+        return
+
+    # Find the first CONCURRENTLY migration to determine target
+    sorted_concurrent = sorted(CONCURRENT_MIGRATIONS)
+    first_concurrent = sorted_concurrent[0]
+    # Apply everything before the first CONCURRENTLY migration
+    before_target = f"{int(first_concurrent) - 1:03d}"
+    result = _run_migrate("migrate", "--target", before_target, "--yes")
+    assert result.returncode == 0, f"Migration failed:\n{result.stdout}\n{result.stderr}"
+
+    # Apply each CONCURRENTLY migration manually
+    for version in sorted_concurrent:
+        _apply_concurrent_migration(version)
+
+    # Apply remaining migrations
+    result = _run_migrate("migrate", "--yes")
+    if result.returncode != 0:
+        assert (
+            "No pending migrations" in result.stdout or result.returncode == 0
+        ), f"Migration failed:\n{result.stdout}\n{result.stderr}"
+
+
+@pytest.mark.integration
+class TestMigrationSequence:
+    """Test full migration sequence on a real database."""
+
+    def test_full_sequence_on_clean_db(self):
+        """All migrations run without error on baseline schema."""
+        _apply_all_migrations()
+
+        result = _run_migrate("status")
+        assert result.returncode == 0
+        assert "Pending: 0" in result.stdout
+
+    def test_status_shows_zero_pending_after_migrate(self):
+        """After applying all migrations, status shows nothing pending."""
+        _apply_all_migrations()
+
+        result = _run_migrate("status")
+        assert result.returncode == 0
+        assert "Pending: 0" in result.stdout
+
+    def test_idempotency_double_run(self):
+        """Running migrate twice is safe — second run is a no-op."""
+        _apply_all_migrations()
+
+        second = _run_migrate("migrate", "--yes")
+        assert second.returncode == 0
+        assert "No pending migrations" in second.stdout
+
+    def test_validate_after_full_sequence(self):
+        """Validate passes after all migrations are applied."""
+        _apply_all_migrations()
+
+        result = _run_migrate("validate", needs_db=False)
+        assert result.returncode == 0
+        assert "consistent" in result.stdout
+
+    def test_rollback_last_and_reapply(self):
+        """Rollback of last non-concurrent migration + re-apply works."""
+        _apply_all_migrations()
+
+        # Find the last non-CONCURRENTLY migration with a rollback file
+        all_migrations = sorted(MIGRATIONS_DIR.glob("[0-9][0-9][0-9]_*"))
+        candidates = [
+            m
+            for m in all_migrations
+            if m.name[:3] not in CONCURRENT_MIGRATIONS
+            and not m.name.endswith("_rollback.sql")
+            and not m.suffix == ".py"
+        ]
+        rollback_target = None
+        for m in reversed(candidates):
+            version = m.name[:3]
+            if list(MIGRATIONS_DIR.glob(f"{version}_*_rollback.sql")):
+                rollback_target = version
+                break
+
+        if not rollback_target:
+            pytest.skip("No non-concurrent SQL migration with rollback file found")
+
+        result = _run_migrate("rollback", rollback_target, "--yes")
+        assert result.returncode == 0, f"Rollback failed:\n{result.stdout}\n{result.stderr}"
+
+        result = _run_migrate("migrate", "--yes")
+        assert result.returncode == 0
+        assert "migration(s) processed" in result.stdout
+
+    def test_stamp_then_migrate(self):
+        """Stamp first N migrations, then migrate applies only the rest."""
+        result = _run_migrate("stamp", "007", "--yes")
+        assert result.returncode == 0
+        assert "stamped" in result.stdout.lower()
+
+        # Apply remaining (handling CONCURRENTLY ones)
+        if CONCURRENT_MIGRATIONS:
+            for version in sorted(CONCURRENT_MIGRATIONS):
+                if int(version) > 7:
+                    # Apply up to before the concurrent migration
+                    before = f"{int(version) - 1:03d}"
+                    _run_migrate("migrate", "--target", before, "--yes")
+                    _apply_concurrent_migration(version)
+            _run_migrate("migrate", "--yes")
+        else:
+            result = _run_migrate("migrate", "--yes")
+            assert result.returncode == 0
+
+        result = _run_migrate("status")
+        assert "Pending: 0" in result.stdout


### PR DESCRIPTION
## Summary

Implementa os criterios de aceite remanescentes da issue #133 (melhorias no sistema de migrations), originada pelo incidente de re-execucao acidental de migrations durante o deploy do monitoramento (#73).

- Adiciona step de pre-flight no workflow `db-migrate.yaml` que mostra pending migrations ANTES de executar e emite warning quando count > 3
- Cria workflow `ci-migrations.yaml` com testes de integracao contra PostgreSQL real (pgvector/pgvector:pg16) para PRs que alteram migrations
- Documenta o comando `stamp` (cenarios de uso, diferenca vs. migrate) e a convenção de idempotencia (patterns, checklist de review)

## Motivacao

O incidente original: o runner tentou re-executar migrations 001-007 porque `migration_history` estava vazia. O pre-flight check teria alertado o operador sobre a contagem anormal de pending migrations antes da execucao.

Os testes de integracao teriam detectado o bug da migration 005 (nao-idempotente) antes de chegar a producao.

## Principais mudancas

| Arquivo | Mudanca |
|---------|---------|
| `.github/workflows/db-migrate.yaml` | Step "Pre-flight migration status" antes de "Execute migration command" |
| `.github/workflows/ci-migrations.yaml` | Novo workflow com PostgreSQL service container |
| `tests/integration/test_migrate_integration.py` | 6 testes: sequencia completa, idempotencia, validate, rollback+reapply, stamp+migrate |
| `docs/database/migrations.md` | Secoes "Stamp Command" e "Idempotency Convention" |

## Decisoes tecnicas

- **Pre-flight como step, nao job**: evita duplicar toda a infraestrutura (Cloud SQL Proxy, Python setup, auth) em um job separado. Reusa o contexto existente do job `run-migration`.
- **`continue-on-error: true`** no pre-flight: se `status` falhar (rede, permissao), nao bloqueia o deploy. O warning e informativo.
- **Deteccao automatica de CONCURRENTLY**: testes de integracao detectam migrations com `CREATE INDEX CONCURRENTLY` e as aplicam fora de transacao (removendo keyword), ja que o runner usa transacoes implicitas.
- **Threshold > 3**: normal sao 1-2 migrations por deploy. 3+ e incomum. O incidente original tinha 7 pending.

## Atencao dos reviewers

1. **Migration 012** usa `CREATE INDEX CONCURRENTLY` que nao roda dentro de transacao. O teste contorna removendo `CONCURRENTLY` no ambiente de teste. Em producao isso funciona? Verificar se ja foi aplicada manualmente ou se o runner tem algum mecanismo especial.
2. O workflow `ci-migrations.yaml` usa `poetry install --no-interaction` (instala tudo). Se o projeto tiver dependencias pesadas, considerar `--only main` + psycopg2.

## Estrategia de testes

- 6 testes de integracao rodando contra PostgreSQL 16 + pgvector
- Cada teste reseta o DB para baseline (schema pre-migrations) via `DROP SCHEMA public CASCADE`
- Validado localmente: 6/6 pass, 534 unit tests sem regressao

## Riscos

- Pre-flight adiciona ~2s ao workflow (tempo do `status` query). Aceitavel para workflow manual.
- Se novas migrations tambem usarem CONCURRENTLY, os testes vao detectar e tratar automaticamente.

## Test plan

- [x] Testes de integracao passam localmente (6/6)
- [x] Unit tests sem regressao (534 passed)
- [x] Lint/format clean (ruff)
- [ ] Verificar CI passa no PR (workflow ci-migrations.yaml)
- [ ] Testar workflow db-migrate.yaml com command=migrate dry_run=true em staging