### PR TITLE
fix: suportar migrations autocommit para CREATE INDEX CONCURRENTLY

### DIFF
--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -167,7 +167,8 @@ def _requires_autocommit(migration: MigrationInfo) -> bool:
     """Check if a SQL migration requires autocommit mode (e.g. CONCURRENTLY)."""
     if migration.migration_type != "sql":
         return False
-    first_line = migration.path.read_text().split("\n", 1)[0]
+    content = migration.path.read_text().lstrip("﻿ \t\n\r")
+    first_line = content.split("\n", 1)[0]
     return "-- migrate: autocommit" in first_line
 
 
@@ -415,60 +416,99 @@ def _execute_autocommit(
     Statements are executed individually because PostgreSQL does not allow
     CONCURRENTLY within a multi-statement query block.
 
+    History is pre-recorded before execution to avoid audit loss if the process
+    crashes between SQL commit (autocommit) and history recording. On crash,
+    history retains the pre-recorded entry; on success/failure, it is updated.
+
     Autocommit migrations cannot be rolled back automatically. If the operation
-    fails midway (e.g. partial index), the operator must clean up manually.
+    fails midway (e.g. partial index marked INVALID), the operator must DROP
+    the index and retry.
     """
     started_at = time.time()
+
+    sql = migration.path.read_text()
+    statements = _split_sql_statements(sql)
     logger.info(
-        f"Executing {migration.version}_{migration.name} ({migration.migration_type}, autocommit)"
+        f"Executing {migration.version}_{migration.name} "
+        f"(autocommit, {len(statements)} statement(s))"
     )
 
+    # Pre-record history before executing (avoids audit loss on crash)
+    _record_history(
+        conn,
+        migration,
+        "migrate",
+        "failed",
+        started_at,
+        applied_by,
+        run_id,
+        description="autocommit: pre-recorded before execution",
+    )
     conn.commit()
+
+    # Execute SQL in autocommit mode
     conn.autocommit = True
     try:
-        sql = migration.path.read_text()
-        statements = _split_sql_statements(sql)
         cursor = conn.cursor()
         try:
-            for stmt in statements:
+            for i, stmt in enumerate(statements, 1):
+                logger.debug(f"[{i}/{len(statements)}] {stmt[:80].replace(chr(10), ' ')}...")
                 cursor.execute(stmt)
         finally:
             cursor.close()
     except Exception as e:
         conn.autocommit = False
-        _record_history(
-            conn,
-            migration,
-            "migrate",
-            "failed",
-            started_at,
-            applied_by,
-            run_id,
-            error_message=str(e),
-        )
+        _update_autocommit_history(conn, migration, "failed", started_at, str(e))
         conn.commit()
         raise
     finally:
         conn.autocommit = False
 
-    _record_history(
-        conn,
-        migration,
-        "migrate",
-        "success",
-        started_at,
-        applied_by,
-        run_id,
-    )
+    # Update pre-recorded entry to success
+    _update_autocommit_history(conn, migration, "success", started_at)
     conn.commit()
     logger.info(f"{migration.version}_{migration.name} migrated successfully (autocommit)")
 
 
+def _update_autocommit_history(
+    conn,
+    migration: MigrationInfo,
+    status: str,
+    started_at: float,
+    error_message: str | None = None,
+) -> None:
+    """Update the pre-recorded history entry for an autocommit migration."""
+    duration_ms = int((time.time() - started_at) * 1000)
+    cursor = conn.cursor()
+    try:
+        cursor.execute(
+            """
+            UPDATE migration_history
+            SET status = %s,
+                duration_ms = %s,
+                finished_at = NOW(),
+                error_message = %s,
+                description = NULL
+            WHERE version = %s
+              AND operation = 'migrate'
+              AND description = 'autocommit: pre-recorded before execution'
+            """,
+            (status, duration_ms, error_message, migration.version),
+        )
+    finally:
+        cursor.close()
+
+
 def _split_sql_statements(sql: str) -> list[str]:
-    """Split SQL into individual statements, skipping comments and empty lines."""
+    """Split SQL into individual statements for autocommit execution.
+
+    Simple split by ';' — does NOT handle semicolons inside string literals,
+    dollar-quoted blocks ($$...$$), or multi-line comments. Autocommit migrations
+    should contain only simple DDL (CREATE INDEX, CREATE DATABASE, VACUUM).
+    For PL/pgSQL or complex SQL, use standard transactional migrations.
+    """
     statements = []
     for raw in sql.split(";"):
-        # Remove comment-only lines and whitespace
         lines = [ln for ln in raw.split("\n") if ln.strip() and not ln.strip().startswith("--")]
         stmt = "\n".join(lines).strip()
         if stmt:

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -104,6 +104,7 @@ SELECT DISTINCT version FROM migration_status WHERE operation = 'migrate'
 # Data structures
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class MigrationInfo:
     version: str
@@ -116,6 +117,7 @@ class MigrationInfo:
 # ---------------------------------------------------------------------------
 # Discovery
 # ---------------------------------------------------------------------------
+
 
 def discover_migrations(migrations_dir: Path) -> list[MigrationInfo]:
     """Discover migration files in a directory by naming convention."""
@@ -157,8 +159,22 @@ def discover_migrations(migrations_dir: Path) -> list[MigrationInfo]:
 
 
 # ---------------------------------------------------------------------------
+# Autocommit detection
+# ---------------------------------------------------------------------------
+
+
+def _requires_autocommit(migration: MigrationInfo) -> bool:
+    """Check if a SQL migration requires autocommit mode (e.g. CONCURRENTLY)."""
+    if migration.migration_type != "sql":
+        return False
+    first_line = migration.path.read_text().split("\n", 1)[0]
+    return "-- migrate: autocommit" in first_line
+
+
+# ---------------------------------------------------------------------------
 # Bootstrap
 # ---------------------------------------------------------------------------
+
 
 def bootstrap(conn) -> None:
     """Create migration_history table and import schema_version if present."""
@@ -194,6 +210,7 @@ def bootstrap(conn) -> None:
 # Status / Pending
 # ---------------------------------------------------------------------------
 
+
 def get_pending(
     conn, migrations: list[MigrationInfo], target: str | None = None
 ) -> list[MigrationInfo]:
@@ -216,6 +233,7 @@ def get_pending(
 # ---------------------------------------------------------------------------
 # Record history
 # ---------------------------------------------------------------------------
+
 
 def _record_history(
     conn,
@@ -261,6 +279,7 @@ def _record_history(
 # Execute migration
 # ---------------------------------------------------------------------------
 
+
 def _load_python_module(path: Path):
     """Dynamically load a Python migration module."""
     module_name = f"migration_{path.stem}"
@@ -297,15 +316,29 @@ def _execute_with_history(
 
         if dry_run:
             _record_history(
-                conn, migration, effective_op, "success", started_at,
-                applied_by, run_id, description, execution_details,
+                conn,
+                migration,
+                effective_op,
+                "success",
+                started_at,
+                applied_by,
+                run_id,
+                description,
+                execution_details,
             )
             conn.rollback()
             logger.info(f"[DRY RUN] {migration.version} previewed (rolled back)")
         else:
             _record_history(
-                conn, migration, effective_op, "success", started_at,
-                applied_by, run_id, description, execution_details,
+                conn,
+                migration,
+                effective_op,
+                "success",
+                started_at,
+                applied_by,
+                run_id,
+                description,
+                execution_details,
             )
             conn.commit()
             logger.info(f"{migration.version}_{migration.name} {operation}d successfully")
@@ -316,8 +349,14 @@ def _execute_with_history(
         conn.rollback()
         try:
             _record_history(
-                conn, migration, effective_op, "failed", started_at,
-                applied_by, run_id, error_message=str(e),
+                conn,
+                migration,
+                effective_op,
+                "failed",
+                started_at,
+                applied_by,
+                run_id,
+                error_message=str(e),
             )
             conn.commit()
         except Exception:
@@ -333,6 +372,16 @@ def execute_migration(
     run_id: str | None,
 ) -> None:
     """Execute a single migration (SQL or Python) with atomic commit."""
+
+    if _requires_autocommit(migration):
+        if dry_run:
+            logger.info(
+                f"[DRY RUN] Skipping {migration.version}_{migration.name} "
+                f"(autocommit migration cannot be previewed)"
+            )
+            return
+        _execute_autocommit(conn, migration, applied_by, run_id)
+        return
 
     def action(conn):
         if migration.migration_type == "sql":
@@ -355,9 +404,82 @@ def execute_migration(
     _execute_with_history(conn, migration, "migrate", dry_run, applied_by, run_id, action)
 
 
+def _execute_autocommit(
+    conn,
+    migration: MigrationInfo,
+    applied_by: str,
+    run_id: str | None,
+) -> None:
+    """Execute a migration requiring autocommit (e.g. CREATE INDEX CONCURRENTLY).
+
+    Statements are executed individually because PostgreSQL does not allow
+    CONCURRENTLY within a multi-statement query block.
+
+    Autocommit migrations cannot be rolled back automatically. If the operation
+    fails midway (e.g. partial index), the operator must clean up manually.
+    """
+    started_at = time.time()
+    logger.info(
+        f"Executing {migration.version}_{migration.name} ({migration.migration_type}, autocommit)"
+    )
+
+    conn.commit()
+    conn.autocommit = True
+    try:
+        sql = migration.path.read_text()
+        statements = _split_sql_statements(sql)
+        cursor = conn.cursor()
+        try:
+            for stmt in statements:
+                cursor.execute(stmt)
+        finally:
+            cursor.close()
+    except Exception as e:
+        conn.autocommit = False
+        _record_history(
+            conn,
+            migration,
+            "migrate",
+            "failed",
+            started_at,
+            applied_by,
+            run_id,
+            error_message=str(e),
+        )
+        conn.commit()
+        raise
+    finally:
+        conn.autocommit = False
+
+    _record_history(
+        conn,
+        migration,
+        "migrate",
+        "success",
+        started_at,
+        applied_by,
+        run_id,
+    )
+    conn.commit()
+    logger.info(f"{migration.version}_{migration.name} migrated successfully (autocommit)")
+
+
+def _split_sql_statements(sql: str) -> list[str]:
+    """Split SQL into individual statements, skipping comments and empty lines."""
+    statements = []
+    for raw in sql.split(";"):
+        # Remove comment-only lines and whitespace
+        lines = [ln for ln in raw.split("\n") if ln.strip() and not ln.strip().startswith("--")]
+        stmt = "\n".join(lines).strip()
+        if stmt:
+            statements.append(stmt)
+    return statements
+
+
 # ---------------------------------------------------------------------------
 # Execute rollback
 # ---------------------------------------------------------------------------
+
 
 def execute_rollback(
     conn,
@@ -388,8 +510,14 @@ def execute_rollback(
                 return None, result if isinstance(result, dict) else None
             except NotImplementedError as nie:
                 _record_history(
-                    conn, migration, "rollback", "unavailable", time.time(),
-                    applied_by, run_id, error_message=str(nie),
+                    conn,
+                    migration,
+                    "rollback",
+                    "unavailable",
+                    time.time(),
+                    applied_by,
+                    run_id,
+                    error_message=str(nie),
                 )
                 conn.commit()
                 logger.warning(f"{migration.version} rollback unavailable: {nie}")
@@ -407,6 +535,7 @@ def execute_rollback(
 # ---------------------------------------------------------------------------
 # Validate
 # ---------------------------------------------------------------------------
+
 
 def validate_migrations(migrations: list[MigrationInfo]) -> list[str]:
     """Check for sequence gaps and other issues."""
@@ -426,6 +555,7 @@ def validate_migrations(migrations: list[MigrationInfo]) -> list[str]:
 # ---------------------------------------------------------------------------
 # CLI (typer)
 # ---------------------------------------------------------------------------
+
 
 def _get_applied_by() -> str:
     """Determine who is running the migration."""
@@ -508,7 +638,9 @@ def main():
             for m in pending:
                 execute_migration(conn, m, dry_run=dry_run, applied_by=applied_by, run_id=run_id)
 
-            typer.echo(f"\n{'[DRY RUN] ' if dry_run else ''}Done: {len(pending)} migration(s) processed.")
+            typer.echo(
+                f"\n{'[DRY RUN] ' if dry_run else ''}Done: {len(pending)} migration(s) processed."
+            )
         finally:
             conn.close()
 
@@ -564,12 +696,16 @@ def main():
                 typer.echo("No migration history.")
                 return
 
-            typer.echo(f"{'Ver':>5} {'Name':<30} {'Type':<8} {'Op':<10} {'Status':<12} {'By':<15} {'Duration':>10}")
+            typer.echo(
+                f"{'Ver':>5} {'Name':<30} {'Type':<8} {'Op':<10} {'Status':<12} {'By':<15} {'Duration':>10}"
+            )
             typer.echo("-" * 95)
             for row in rows:
                 ver, name, mtype, op, st, by, at, dur, err = row
                 dur_str = f"{dur}ms" if dur else "-"
-                typer.echo(f"{ver:>5} {name:<30} {mtype:<8} {op:<10} {st:<12} {by:<15} {dur_str:>10}")
+                typer.echo(
+                    f"{ver:>5} {name:<30} {mtype:<8} {op:<10} {st:<12} {by:<15} {dur_str:>10}"
+                )
                 if err:
                     typer.echo(f"      Error: {err[:80]}")
         finally:
@@ -621,17 +757,20 @@ def main():
                 typer.echo(f"  {m.version}_{m.name} ({m.migration_type})")
 
             if not yes:
-                typer.confirm(
-                    "Stamp these migrations as applied without running them?", abort=True
-                )
+                typer.confirm("Stamp these migrations as applied without running them?", abort=True)
 
             applied_by = _get_applied_by()
             run_id = _get_run_id()
 
             for m in pending:
                 _record_history(
-                    conn, m, "migrate", "success", time.time(),
-                    applied_by, run_id,
+                    conn,
+                    m,
+                    "migrate",
+                    "success",
+                    time.time(),
+                    applied_by,
+                    run_id,
                     description="Stamped as applied — existing database bootstrap",
                 )
                 conn.commit()

--- a/scripts/migrations/012_add_url_unique_index.sql
+++ b/scripts/migrations/012_add_url_unique_index.sql
@@ -1,3 +1,4 @@
+-- migrate: autocommit
 -- 012_add_url_unique_index.sql
 -- Cria indice unico parcial em (agency_key, url) para prevenir duplicatas.
 -- DEVE ser executado DEPOIS do cleanup de duplicatas (011).

--- a/tests/scripts/test_migrate_runner.py
+++ b/tests/scripts/test_migrate_runner.py
@@ -102,7 +102,9 @@ class TestBootstrap:
 
         # Should have executed CREATE TABLE
         executed_sqls = [c[0][0] for c in cursor.execute.call_args_list]
-        create_calls = [s for s in executed_sqls if "CREATE TABLE" in s and "migration_history" in s]
+        create_calls = [
+            s for s in executed_sqls if "CREATE TABLE" in s and "migration_history" in s
+        ]
         assert len(create_calls) >= 1
 
         conn.commit.assert_called()
@@ -163,9 +165,27 @@ class TestGetPending:
         from migrate import MigrationInfo, get_pending
 
         migrations = [
-            MigrationInfo(version="001", name="first", path=Path("001.sql"), migration_type="sql", rollback_path=None),
-            MigrationInfo(version="002", name="second", path=Path("002.sql"), migration_type="sql", rollback_path=None),
-            MigrationInfo(version="003", name="third", path=Path("003.py"), migration_type="python", rollback_path=None),
+            MigrationInfo(
+                version="001",
+                name="first",
+                path=Path("001.sql"),
+                migration_type="sql",
+                rollback_path=None,
+            ),
+            MigrationInfo(
+                version="002",
+                name="second",
+                path=Path("002.sql"),
+                migration_type="sql",
+                rollback_path=None,
+            ),
+            MigrationInfo(
+                version="003",
+                name="third",
+                path=Path("003.py"),
+                migration_type="python",
+                rollback_path=None,
+            ),
         ]
         pending = get_pending(conn, migrations)
         assert [m.version for m in pending] == ["002", "003"]
@@ -181,8 +201,20 @@ class TestGetPending:
         from migrate import MigrationInfo, get_pending
 
         migrations = [
-            MigrationInfo(version="001", name="first", path=Path("001.sql"), migration_type="sql", rollback_path=None),
-            MigrationInfo(version="002", name="second", path=Path("002.sql"), migration_type="sql", rollback_path=None),
+            MigrationInfo(
+                version="001",
+                name="first",
+                path=Path("001.sql"),
+                migration_type="sql",
+                rollback_path=None,
+            ),
+            MigrationInfo(
+                version="002",
+                name="second",
+                path=Path("002.sql"),
+                migration_type="sql",
+                rollback_path=None,
+            ),
         ]
         pending = get_pending(conn, migrations)
         assert pending == []
@@ -198,9 +230,27 @@ class TestGetPending:
         from migrate import MigrationInfo, get_pending
 
         migrations = [
-            MigrationInfo(version="001", name="first", path=Path("001.sql"), migration_type="sql", rollback_path=None),
-            MigrationInfo(version="002", name="second", path=Path("002.sql"), migration_type="sql", rollback_path=None),
-            MigrationInfo(version="003", name="third", path=Path("003.sql"), migration_type="sql", rollback_path=None),
+            MigrationInfo(
+                version="001",
+                name="first",
+                path=Path("001.sql"),
+                migration_type="sql",
+                rollback_path=None,
+            ),
+            MigrationInfo(
+                version="002",
+                name="second",
+                path=Path("002.sql"),
+                migration_type="sql",
+                rollback_path=None,
+            ),
+            MigrationInfo(
+                version="003",
+                name="third",
+                path=Path("003.sql"),
+                migration_type="sql",
+                rollback_path=None,
+            ),
         ]
         pending = get_pending(conn, migrations, target="002")
         assert [m.version for m in pending] == ["001", "002"]
@@ -224,8 +274,11 @@ class TestExecuteMigrationSQL:
         from migrate import MigrationInfo, execute_migration
 
         migration = MigrationInfo(
-            version="001", name="test", path=sql_file,
-            migration_type="sql", rollback_path=None,
+            version="001",
+            name="test",
+            path=sql_file,
+            migration_type="sql",
+            rollback_path=None,
         )
         execute_migration(conn, migration, dry_run=False, applied_by="test", run_id=None)
 
@@ -253,8 +306,11 @@ class TestExecuteMigrationSQL:
         from migrate import MigrationInfo, execute_migration
 
         migration = MigrationInfo(
-            version="001", name="test", path=sql_file,
-            migration_type="sql", rollback_path=None,
+            version="001",
+            name="test",
+            path=sql_file,
+            migration_type="sql",
+            rollback_path=None,
         )
         execute_migration(conn, migration, dry_run=True, applied_by="test", run_id=None)
 
@@ -284,8 +340,11 @@ class TestExecuteMigrationSQL:
         from migrate import MigrationInfo, execute_migration
 
         migration = MigrationInfo(
-            version="001", name="bad", path=sql_file,
-            migration_type="sql", rollback_path=None,
+            version="001",
+            name="bad",
+            path=sql_file,
+            migration_type="sql",
+            rollback_path=None,
         )
         with pytest.raises(Exception, match="syntax error"):
             execute_migration(conn, migration, dry_run=False, applied_by="test", run_id=None)
@@ -302,7 +361,7 @@ class TestExecuteMigrationPython:
         py_file.write_text(
             'def describe(): return "Test migration"\n'
             'def migrate(conn, dry_run=False): return {"rows_affected": 42}\n'
-            'def rollback(conn, dry_run=False): return {}\n'
+            "def rollback(conn, dry_run=False): return {}\n"
         )
 
         conn = MagicMock()
@@ -314,8 +373,11 @@ class TestExecuteMigrationPython:
         from migrate import MigrationInfo, execute_migration
 
         migration = MigrationInfo(
-            version="001", name="test_migration", path=py_file,
-            migration_type="python", rollback_path=None,
+            version="001",
+            name="test_migration",
+            path=py_file,
+            migration_type="python",
+            rollback_path=None,
         )
         execute_migration(conn, migration, dry_run=False, applied_by="test", run_id=None)
         conn.commit.assert_called()
@@ -325,7 +387,7 @@ class TestExecuteMigrationPython:
         py_file.write_text(
             'def describe(): return "Test"\n'
             'def migrate(conn, dry_run=False): return {"rows_affected": 42, "collisions": 0}\n'
-            'def rollback(conn, dry_run=False): return {}\n'
+            "def rollback(conn, dry_run=False): return {}\n"
         )
 
         conn = MagicMock()
@@ -337,8 +399,11 @@ class TestExecuteMigrationPython:
         from migrate import MigrationInfo, execute_migration
 
         migration = MigrationInfo(
-            version="001", name="test_migration", path=py_file,
-            migration_type="python", rollback_path=None,
+            version="001",
+            name="test_migration",
+            path=py_file,
+            migration_type="python",
+            rollback_path=None,
         )
         execute_migration(conn, migration, dry_run=False, applied_by="test", run_id=None)
 
@@ -352,9 +417,7 @@ class TestExecuteMigrationPython:
 
     def test_module_without_describe_raises(self, tmp_path):
         py_file = tmp_path / "001_bad.py"
-        py_file.write_text(
-            'def migrate(conn, dry_run=False): return {}\n'
-        )
+        py_file.write_text("def migrate(conn, dry_run=False): return {}\n")
 
         conn = MagicMock()
         cursor = MagicMock()
@@ -365,8 +428,11 @@ class TestExecuteMigrationPython:
         from migrate import MigrationInfo, execute_migration
 
         migration = MigrationInfo(
-            version="001", name="bad", path=py_file,
-            migration_type="python", rollback_path=None,
+            version="001",
+            name="bad",
+            path=py_file,
+            migration_type="python",
+            rollback_path=None,
         )
         with pytest.raises((AttributeError, Exception)):
             execute_migration(conn, migration, dry_run=False, applied_by="test", run_id=None)
@@ -391,8 +457,11 @@ class TestExecuteRollback:
         from migrate import MigrationInfo, execute_rollback
 
         migration = MigrationInfo(
-            version="001", name="create", path=migration_file,
-            migration_type="sql", rollback_path=rollback_file,
+            version="001",
+            name="create",
+            path=migration_file,
+            migration_type="sql",
+            rollback_path=rollback_file,
         )
         execute_rollback(conn, migration, dry_run=False, applied_by="test", run_id=None)
 
@@ -405,7 +474,7 @@ class TestExecuteRollback:
         py_file = tmp_path / "001_data.py"
         py_file.write_text(
             'def describe(): return "Test"\n'
-            'def migrate(conn, dry_run=False): return {}\n'
+            "def migrate(conn, dry_run=False): return {}\n"
             'def rollback(conn, dry_run=False): return {"restored": 10}\n'
         )
 
@@ -418,8 +487,11 @@ class TestExecuteRollback:
         from migrate import MigrationInfo, execute_rollback
 
         migration = MigrationInfo(
-            version="001", name="data", path=py_file,
-            migration_type="python", rollback_path=None,
+            version="001",
+            name="data",
+            path=py_file,
+            migration_type="python",
+            rollback_path=None,
         )
         execute_rollback(conn, migration, dry_run=False, applied_by="test", run_id=None)
         conn.commit.assert_called()
@@ -433,8 +505,11 @@ class TestExecuteRollback:
         from migrate import MigrationInfo, execute_rollback
 
         migration = MigrationInfo(
-            version="001", name="create", path=migration_file,
-            migration_type="sql", rollback_path=None,
+            version="001",
+            name="create",
+            path=migration_file,
+            migration_type="sql",
+            rollback_path=None,
         )
         with pytest.raises((FileNotFoundError, ValueError)):
             execute_rollback(conn, migration, dry_run=False, applied_by="test", run_id=None)
@@ -443,7 +518,7 @@ class TestExecuteRollback:
         py_file = tmp_path / "001_data.py"
         py_file.write_text(
             'def describe(): return "Test"\n'
-            'def migrate(conn, dry_run=False): return {}\n'
+            "def migrate(conn, dry_run=False): return {}\n"
             'def rollback(conn, dry_run=False): raise NotImplementedError("Cannot rollback")\n'
         )
 
@@ -456,8 +531,11 @@ class TestExecuteRollback:
         from migrate import MigrationInfo, execute_rollback
 
         migration = MigrationInfo(
-            version="001", name="data", path=py_file,
-            migration_type="python", rollback_path=None,
+            version="001",
+            name="data",
+            path=py_file,
+            migration_type="python",
+            rollback_path=None,
         )
         # Should not raise — records unavailable instead
         execute_rollback(conn, migration, dry_run=False, applied_by="test", run_id=None)
@@ -480,8 +558,11 @@ class TestExecuteRollback:
         from migrate import MigrationInfo, execute_rollback
 
         migration = MigrationInfo(
-            version="001", name="create", path=migration_file,
-            migration_type="sql", rollback_path=rollback_file,
+            version="001",
+            name="create",
+            path=migration_file,
+            migration_type="sql",
+            rollback_path=rollback_file,
         )
         execute_rollback(conn, migration, dry_run=False, applied_by="test", run_id=None)
 
@@ -542,12 +623,15 @@ class TestStamp:
         import migrate
 
         with patch.object(
-            sys, "argv",
+            sys,
+            "argv",
             ["migrate.py", "stamp", target, "--db-url", "postgresql://test", "--yes"],
         ), patch("psycopg2.connect", return_value=mock_conn), patch.object(
             migrate, "bootstrap"
         ), patch.object(
-            migrate, "discover_migrations", return_value=self._make_migrations(
+            migrate,
+            "discover_migrations",
+            return_value=self._make_migrations(
                 [m.version for m in pending]
                 + [v for v in ["001", "002", "003", "004", "005"] if v <= target]
             ),
@@ -557,9 +641,7 @@ class TestStamp:
             migrate, "_record_history"
         ) as mock_record, patch.object(
             migrate, "_get_applied_by", return_value="test-user"
-        ), patch.object(
-            migrate, "_get_run_id", return_value=None
-        ):
+        ), patch.object(migrate, "_get_run_id", return_value=None):
             with pytest.raises(SystemExit) as exc_info:
                 migrate.main()
             assert exc_info.value.code in (None, 0)
@@ -575,8 +657,8 @@ class TestStamp:
         for c in mock_record.call_args_list:
             args, kwargs = c
             # positional: conn, migration, "migrate", "success", started_at, applied_by, run_id
-            assert args[2] == "migrate"       # operation
-            assert args[3] == "success"       # status
+            assert args[2] == "migrate"  # operation
+            assert args[3] == "success"  # status
             assert "Stamped" in kwargs.get("description", "")
 
     def test_stamp_skips_already_applied(self):
@@ -600,7 +682,9 @@ class TestStamp:
         gp_call = mock_get_pending.call_args
         gp_positional = gp_call[0]
         gp_kwargs = gp_call[1]
-        target_arg = gp_kwargs.get("target") or (gp_positional[2] if len(gp_positional) > 2 else None)
+        target_arg = gp_kwargs.get("target") or (
+            gp_positional[2] if len(gp_positional) > 2 else None
+        )
         assert target_arg == "003"
 
         # Only 001-003 stamped (as returned by mocked get_pending)
@@ -617,3 +701,171 @@ class TestStamp:
         assert mock_record.call_count == 0
         captured = capsys.readouterr()
         assert "Nothing to stamp" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Autocommit detection and execution
+# ---------------------------------------------------------------------------
+class TestAutocommit:
+    def test_requires_autocommit_detects_flag(self, tmp_path):
+        sql_file = tmp_path / "012_create_index.sql"
+        sql_file.write_text("-- migrate: autocommit\nCREATE INDEX CONCURRENTLY ...;")
+
+        from migrate import MigrationInfo, _requires_autocommit
+
+        migration = MigrationInfo(
+            version="012",
+            name="create_index",
+            path=sql_file,
+            migration_type="sql",
+            rollback_path=None,
+        )
+        assert _requires_autocommit(migration) is True
+
+    def test_requires_autocommit_ignores_normal_sql(self, tmp_path):
+        sql_file = tmp_path / "001_normal.sql"
+        sql_file.write_text("-- Normal migration\nCREATE TABLE IF NOT EXISTS t (id INT);")
+
+        from migrate import MigrationInfo, _requires_autocommit
+
+        migration = MigrationInfo(
+            version="001",
+            name="normal",
+            path=sql_file,
+            migration_type="sql",
+            rollback_path=None,
+        )
+        assert _requires_autocommit(migration) is False
+
+    def test_requires_autocommit_ignores_python(self, tmp_path):
+        py_file = tmp_path / "006_migrate.py"
+        py_file.write_text("# -- migrate: autocommit\ndef migrate(conn, dry_run=False): pass")
+
+        from migrate import MigrationInfo, _requires_autocommit
+
+        migration = MigrationInfo(
+            version="006",
+            name="migrate",
+            path=py_file,
+            migration_type="python",
+            rollback_path=None,
+        )
+        assert _requires_autocommit(migration) is False
+
+    def test_execute_autocommit_sets_and_restores(self, tmp_path):
+        sql_file = tmp_path / "012_idx.sql"
+        sql_file.write_text("-- migrate: autocommit\nCREATE INDEX CONCURRENTLY idx ON t(c);")
+
+        from migrate import MigrationInfo, _execute_autocommit
+
+        migration = MigrationInfo(
+            version="012",
+            name="idx",
+            path=sql_file,
+            migration_type="sql",
+            rollback_path=None,
+        )
+
+        autocommit_log = []
+
+        class FakeConn:
+            _autocommit = False
+
+            @property
+            def autocommit(self):
+                return self._autocommit
+
+            @autocommit.setter
+            def autocommit(self, value):
+                autocommit_log.append(value)
+                self._autocommit = value
+
+            def commit(self):
+                pass
+
+            def cursor(self):
+                cursor = MagicMock()
+                return cursor
+
+        conn = FakeConn()
+        with patch("migrate._record_history"):
+            _execute_autocommit(conn, migration, "test_user", None)
+
+        # autocommit should have been set True then False
+        assert autocommit_log == [True, False]
+        assert conn.autocommit is False
+
+    def test_execute_autocommit_records_history_on_success(self, tmp_path):
+        sql_file = tmp_path / "012_idx.sql"
+        sql_file.write_text("-- migrate: autocommit\nSELECT 1;")
+
+        from migrate import MigrationInfo, _execute_autocommit
+
+        migration = MigrationInfo(
+            version="012",
+            name="idx",
+            path=sql_file,
+            migration_type="sql",
+            rollback_path=None,
+        )
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value = cursor
+
+        with patch("migrate._record_history") as mock_record:
+            _execute_autocommit(conn, migration, "test_user", "run123")
+
+        mock_record.assert_called_once()
+        call_kwargs = mock_record.call_args
+        assert call_kwargs[0][3] == "success"  # status arg
+        assert call_kwargs[0][4] is not None  # started_at
+
+    def test_execute_autocommit_records_failure_and_reraises(self, tmp_path):
+        sql_file = tmp_path / "012_idx.sql"
+        sql_file.write_text("-- migrate: autocommit\nINVALID SQL;")
+
+        from migrate import MigrationInfo, _execute_autocommit
+
+        migration = MigrationInfo(
+            version="012",
+            name="idx",
+            path=sql_file,
+            migration_type="sql",
+            rollback_path=None,
+        )
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("syntax error")
+        conn.cursor.return_value = cursor
+
+        with patch("migrate._record_history") as mock_record:
+            with pytest.raises(Exception, match="syntax error"):
+                _execute_autocommit(conn, migration, "test_user", None)
+
+        mock_record.assert_called_once()
+        call_args = mock_record.call_args[0]
+        assert call_args[3] == "failed"  # status
+        call_kwargs = mock_record.call_args[1]
+        assert "syntax error" in call_kwargs["error_message"]
+
+    def test_execute_migration_skips_autocommit_on_dry_run(self, tmp_path, capsys):
+        sql_file = tmp_path / "012_idx.sql"
+        sql_file.write_text("-- migrate: autocommit\nCREATE INDEX CONCURRENTLY idx ON t(c);")
+
+        from migrate import MigrationInfo, execute_migration
+
+        migration = MigrationInfo(
+            version="012",
+            name="idx",
+            path=sql_file,
+            migration_type="sql",
+            rollback_path=None,
+        )
+
+        conn = MagicMock()
+        execute_migration(conn, migration, dry_run=True, applied_by="test", run_id=None)
+
+        # Should not execute anything on the connection
+        conn.cursor.assert_not_called()

--- a/tests/scripts/test_migrate_runner.py
+++ b/tests/scripts/test_migrate_runner.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -788,14 +789,14 @@ class TestAutocommit:
                 return cursor
 
         conn = FakeConn()
-        with patch("migrate._record_history"):
+        with patch("migrate._record_history"), patch("migrate._update_autocommit_history"):
             _execute_autocommit(conn, migration, "test_user", None)
 
         # autocommit should have been set True then False
         assert autocommit_log == [True, False]
         assert conn.autocommit is False
 
-    def test_execute_autocommit_records_history_on_success(self, tmp_path):
+    def test_execute_autocommit_prerecords_then_updates_success(self, tmp_path):
         sql_file = tmp_path / "012_idx.sql"
         sql_file.write_text("-- migrate: autocommit\nSELECT 1;")
 
@@ -813,15 +814,21 @@ class TestAutocommit:
         cursor = MagicMock()
         conn.cursor.return_value = cursor
 
-        with patch("migrate._record_history") as mock_record:
+        with (
+            patch("migrate._record_history") as mock_record,
+            patch("migrate._update_autocommit_history") as mock_update,
+        ):
             _execute_autocommit(conn, migration, "test_user", "run123")
 
+        # Pre-records with status="failed" as safety net
         mock_record.assert_called_once()
-        call_kwargs = mock_record.call_args
-        assert call_kwargs[0][3] == "success"  # status arg
-        assert call_kwargs[0][4] is not None  # started_at
+        assert mock_record.call_args[0][3] == "failed"
 
-    def test_execute_autocommit_records_failure_and_reraises(self, tmp_path):
+        # Updates to success after execution
+        mock_update.assert_called_once()
+        assert mock_update.call_args[0][2] == "success"
+
+    def test_execute_autocommit_updates_failure_and_reraises(self, tmp_path):
         sql_file = tmp_path / "012_idx.sql"
         sql_file.write_text("-- migrate: autocommit\nINVALID SQL;")
 
@@ -840,15 +847,60 @@ class TestAutocommit:
         cursor.execute.side_effect = Exception("syntax error")
         conn.cursor.return_value = cursor
 
-        with patch("migrate._record_history") as mock_record:
+        with (
+            patch("migrate._record_history") as mock_record,
+            patch("migrate._update_autocommit_history") as mock_update,
+        ):
             with pytest.raises(Exception, match="syntax error"):
                 _execute_autocommit(conn, migration, "test_user", None)
 
+        # Pre-record happened
         mock_record.assert_called_once()
-        call_args = mock_record.call_args[0]
-        assert call_args[3] == "failed"  # status
-        call_kwargs = mock_record.call_args[1]
-        assert "syntax error" in call_kwargs["error_message"]
+
+        # Updated to failed with error message
+        mock_update.assert_called_once()
+        assert mock_update.call_args[0][2] == "failed"
+        assert "syntax error" in mock_update.call_args[0][4]
+
+    def test_requires_autocommit_handles_bom(self, tmp_path):
+        sql_file = tmp_path / "012_bom.sql"
+        sql_file.write_text("﻿-- migrate: autocommit\nCREATE INDEX CONCURRENTLY ...;")
+
+        from migrate import MigrationInfo, _requires_autocommit
+
+        migration = MigrationInfo(
+            version="012",
+            name="bom",
+            path=sql_file,
+            migration_type="sql",
+            rollback_path=None,
+        )
+        assert _requires_autocommit(migration) is True
+
+    def test_update_autocommit_history(self):
+        from migrate import MigrationInfo, _update_autocommit_history
+
+        migration = MigrationInfo(
+            version="012",
+            name="idx",
+            path=Path("/dummy"),
+            migration_type="sql",
+            rollback_path=None,
+        )
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value = cursor
+
+        _update_autocommit_history(conn, migration, "success", time.time() - 1.5)
+
+        cursor.execute.assert_called_once()
+        sql = cursor.execute.call_args[0][0]
+        params = cursor.execute.call_args[0][1]
+        assert "UPDATE migration_history" in sql
+        assert params[0] == "success"  # status
+        assert params[1] >= 1500  # duration_ms >= 1.5s
+        assert params[3] == "012"  # version
 
     def test_execute_migration_skips_autocommit_on_dry_run(self, tmp_path, capsys):
         sql_file = tmp_path / "012_idx.sql"


### PR DESCRIPTION
## Summary

- Adiciona suporte a migrations que requerem `autocommit=True` (ex: `CREATE INDEX CONCURRENTLY`)
- Detecção via flag `-- migrate: autocommit` na primeira linha do arquivo SQL
- Execução statement-by-statement em modo autocommit com registro de histórico separado
- Migration 012 (`012_add_url_unique_index.sql`) marcada com a flag

## Contexto

O runner executava todas as migrations dentro de uma transação (`autocommit=False`), o que impede o PostgreSQL de executar `CREATE INDEX CONCURRENTLY`. Descoberto durante os testes de integração do PR #164.

## Mudanças

| Arquivo | Descrição |
|---------|-----------|
| `scripts/migrate.py` | `_requires_autocommit()`, `_execute_autocommit()`, `_split_sql_statements()` |
| `scripts/migrations/012_add_url_unique_index.sql` | Adicionada flag `-- migrate: autocommit` |
| `tests/scripts/test_migrate_runner.py` | 7 novos testes na classe `TestAutocommit` |

## Como funciona

1. Runner lê primeira linha do SQL
2. Se contém `-- migrate: autocommit`, entra no fluxo alternativo
3. Commit da transação pendente + `conn.autocommit = True`
4. SQL é splitado em statements individuais (CONCURRENTLY não funciona em multi-query)
5. Cada statement é executado separadamente
6. Histórico é registrado após execução (não atômico com a migration)
7. `autocommit` é restaurado para `False` no finally

## Dry-run

Migrations autocommit são skippadas em dry-run com log informativo — `CONCURRENTLY` não pode ser previewado dentro de transação.

## Test plan

- [x] 37/37 testes unitários do runner passando
- [x] Testado com PostgreSQL real via Docker (14 migrations executadas, 012 em autocommit)
- [x] `migration_status` mostra 14 APPLIED, 0 pending após execução completa

Closes #165