### PR TITLE
fix: remover workaround ensure_schema da DAG sync_pg_to_bigquery

### DIFF
--- a/scripts/bq_migrate.py
+++ b/scripts/bq_migrate.py
@@ -73,7 +73,8 @@ def get_applied_versions(client) -> set[str]:
     try:
         rows = client.query(query).result()
         return {row.version for row in rows}
-    except Exception:
+    except Exception as e:
+        print(f"  WARNING: could not read migration history: {e}", file=sys.stderr)
         return set()
 
 

--- a/src/data_platform/dags/sync_pg_to_bigquery.py
+++ b/src/data_platform/dags/sync_pg_to_bigquery.py
@@ -44,32 +44,6 @@ logger = logging.getLogger(__name__)
 def sync_pg_to_bigquery():
 
     @task
-    def ensure_schema(**context) -> dict[str, str]:
-        """Workaround: apply ALTER TABLE via Airflow SA (bq-migrate.yaml SA lacks permissions).
-
-        Remove this task once bq-migrate.yaml has bigquery.jobs.create permission.
-        """
-        from google.cloud import bigquery
-        from google.cloud.exceptions import Forbidden
-
-        project_id = Variable.get("gcp_project_id", default_var="inspire-7-finep")
-        client = bigquery.Client(project=project_id)
-
-        sql = (
-            f"ALTER TABLE `{project_id}.dgb_gold.fato_noticias` "
-            f"ADD COLUMN IF NOT EXISTS content_hash STRING"
-        )
-
-        try:
-            client.query(sql).result()
-            logger.info("ensure_schema: content_hash column ensured")
-        except Forbidden as e:
-            logger.error(f"ensure_schema: permission denied — {e}")
-            raise
-
-        return {"status": "success"}
-
-    @task
     def sync_facts(**context):
         """Query PG for previous day's news + features, load into BigQuery."""
         from data_platform.jobs.bigquery.sync_to_bigquery import (
@@ -129,9 +103,8 @@ def sync_pg_to_bigquery():
         sync_dimensions(db_url, project_id)
         return {"status": "success"}
 
-    # ensure_schema runs first, then facts and dims in parallel
-    schema = ensure_schema()
-    schema >> [sync_facts(), sync_dims()]
+    sync_facts()
+    sync_dims()
 
 
 dag_instance = sync_pg_to_bigquery()

--- a/tests/unit/jobs/bigquery/test_sync_to_bigquery.py
+++ b/tests/unit/jobs/bigquery/test_sync_to_bigquery.py
@@ -159,3 +159,19 @@ class TestDagStructure:
         from data_platform.dags.sync_pg_to_bigquery import dag_instance
 
         assert dag_instance.catchup is False
+
+    def test_dag_does_not_have_ensure_schema_task(self):
+        """ensure_schema was a workaround removed in issue #163."""
+        pytest.importorskip("airflow.decorators", reason="Airflow not installed (runs in Cloud Composer only)")
+        from data_platform.dags.sync_pg_to_bigquery import dag_instance
+
+        task_ids = [t.task_id for t in dag_instance.tasks]
+        assert "ensure_schema" not in task_ids
+
+    def test_sync_tasks_have_no_upstream(self):
+        """After removing ensure_schema, sync tasks have no upstream deps."""
+        pytest.importorskip("airflow.decorators", reason="Airflow not installed (runs in Cloud Composer only)")
+        from data_platform.dags.sync_pg_to_bigquery import dag_instance
+
+        for task in dag_instance.tasks:
+            assert len(task.upstream_list) == 0


### PR DESCRIPTION
## Summary

- Remove task `ensure_schema` da DAG `sync_pg_to_bigquery` (workaround do PR #162)
- Ajusta grafo: `sync_facts` e `sync_dims` rodam em paralelo sem upstream dependency
- Adiciona testes de regressao para garantir que o workaround nao volta
- Corrige `get_applied_versions()` em `bq_migrate.py` para logar erros em vez de silenciar (feedback do code review de destaquesgovbr/infra#182)

## Contexto

A SA `github-actions` agora tem `roles/bigquery.jobUser` (infra PR destaquesgovbr/infra#182), permitindo que o workflow `bq-migrate.yaml` execute migracoes BigQuery diretamente. O workaround `ensure_schema` nao e mais necessario.

## Pre-requisito

- [x] Infra PR destaquesgovbr/infra#182 merged e `terraform apply` executado
- [ ] `gh workflow run bq-migrate.yaml -f command=status` retorna sucesso

## Test plan

- [ ] Testes unitarios passam (`pytest tests/unit/jobs/bigquery/ -v`)
- [ ] CI main-workflow passa (lint, typecheck, tests)
- [ ] DAG faz parse sem erros no Cloud Composer
- [ ] Proxima execucao agendada (7 AM UTC) funciona normalmente

Closes #163