### PR TITLE
feat: indexa entidades e view_count no Typesense

### DIFF
--- a/src/data_platform/clients/graphql_client.py
+++ b/src/data_platform/clients/graphql_client.py
@@ -141,6 +141,7 @@ query NewsForTypesense($uniqueId: ID!) {
     themL3Code themL3Label mostSpecificThemeCode mostSpecificThemeLabel
     contentEmbedding sentimentLabel sentimentScore
     trendingScore wordCount hasImage hasVideo imageBroken readabilityFlesch
+    features
   }
 }
 """

--- a/src/data_platform/managers/postgres_manager.py
+++ b/src/data_platform/managers/postgres_manager.py
@@ -553,7 +553,9 @@ class PostgresManager:
                 (nf.features->>'word_count')::int AS word_count,
                 (nf.features->>'has_image')::boolean AS has_image,
                 (nf.features->>'has_video')::boolean AS has_video,
-                (nf.features->>'readability_flesch')::float AS readability_flesch
+                (nf.features->>'readability_flesch')::float AS readability_flesch,
+                (nf.features->>'view_count')::int AS view_count,
+                nf.features->'entities' AS entities
         """
 
         query += """

--- a/src/data_platform/typesense/collection.py
+++ b/src/data_platform/typesense/collection.py
@@ -107,6 +107,15 @@ COLLECTION_SCHEMA: dict[str, Any] = {
         {"name": "has_video", "type": "bool", "facet": True, "optional": True},
         {"name": "image_broken", "type": "bool", "facet": True, "optional": True},
         {"name": "readability_flesch", "type": "float", "facet": False, "optional": True},
+        # Named entities (from news_features.features.entities: [{text, type, count}])
+        # `entities` carries all entity texts (any type); `entity_*` are per-type buckets.
+        {"name": "entities", "type": "string[]", "facet": True, "optional": True},
+        {"name": "entity_org", "type": "string[]", "facet": True, "optional": True},
+        {"name": "entity_per", "type": "string[]", "facet": True, "optional": True},
+        {"name": "entity_loc", "type": "string[]", "facet": True, "optional": True},
+        {"name": "entity_misc", "type": "string[]", "facet": True, "optional": True},
+        # Engagement (from news_features.features.view_count)
+        {"name": "view_count", "type": "int32", "facet": False, "optional": True, "sort": True},
         # Embedding field for semantic search (768 dimensions - BGE-M3)
         {
             "name": "content_embedding",

--- a/src/data_platform/typesense/indexer.py
+++ b/src/data_platform/typesense/indexer.py
@@ -17,6 +17,88 @@ logger = logging.getLogger(__name__)
 # Limite máximo de caracteres para uma tag válida
 MAX_TAG_LENGTH = 100
 
+# Mapeamento de tipo de entidade (news_features.features.entities) → campo Typesense.
+# Tipos não listados (MISC, EVENT, PROGRAM, ...) caem em entity_misc.
+_ENTITY_TYPE_TO_FIELD: dict[str, str] = {
+    "ORG": "entity_org",
+    "PER": "entity_per",
+    "LOC": "entity_loc",
+}
+
+
+def _dedup_preserving_order(values: list[str]) -> list[str]:
+    """Remove duplicados preservando a ordem de primeira ocorrência."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for v in values:
+        if v not in seen:
+            seen.add(v)
+            result.append(v)
+    return result
+
+
+def extract_entity_fields(entities_value: Any) -> dict[str, list[str]]:
+    """
+    Constrói os campos de entidade do Typesense a partir da lista de entidades.
+
+    A lista (de `news_features.features.entities`) tem o formato
+    ``[{"text": str, "type": str, "count": int}, ...]``. O match é exato pelo
+    texto bruto da entidade (v1, sem normalização/canonicalização).
+
+    Args:
+        entities_value: Lista de dicts de entidades (ou None / valor inválido).
+
+    Returns:
+        Dicionário com as chaves ``entities`` (todos os textos, dedup) e
+        ``entity_org``/``entity_per``/``entity_loc``/``entity_misc`` (por tipo).
+        Chaves com lista vazia são omitidas para não popular campos sem dado.
+    """
+    # JSONB pode chegar como string (dependendo do driver/adaptador); tenta parsear.
+    if isinstance(entities_value, str):
+        try:
+            entities_value = json.loads(entities_value)
+        except json.JSONDecodeError:
+            return {}
+
+    if not isinstance(entities_value, list):
+        return {}
+
+    buckets: dict[str, list[str]] = {
+        "entity_org": [],
+        "entity_per": [],
+        "entity_loc": [],
+        "entity_misc": [],
+    }
+    all_texts: list[str] = []
+
+    for entity in entities_value:
+        if not isinstance(entity, dict):
+            continue
+        text = entity.get("text")
+        if not isinstance(text, str):
+            continue
+        text = text.strip()
+        if not text:
+            continue
+
+        entity_type = entity.get("type")
+        entity_type = entity_type.strip().upper() if isinstance(entity_type, str) else ""
+        field = _ENTITY_TYPE_TO_FIELD.get(entity_type, "entity_misc")
+
+        buckets[field].append(text)
+        all_texts.append(text)
+
+    result: dict[str, list[str]] = {}
+    combined = _dedup_preserving_order(all_texts)
+    if combined:
+        result["entities"] = combined
+    for field, texts in buckets.items():
+        deduped = _dedup_preserving_order(texts)
+        if deduped:
+            result[field] = deduped
+
+    return result
+
 
 def clean_tags(tags_value) -> list[str]:
     """
@@ -186,6 +268,17 @@ def prepare_document(row: pd.Series) -> dict[str, Any]:
         val = row.get(field_name)
         if val is not None and not (isinstance(val, float) and pd.isna(val)):
             doc[field_name] = field_type(val)
+
+    # view_count (engagement, de news_features.features.view_count)
+    view_count = row.get("view_count")
+    if view_count is not None and not (isinstance(view_count, float) and pd.isna(view_count)):
+        doc["view_count"] = int(view_count)
+
+    # Entidades nomeadas (de news_features.features.entities)
+    # Usa `in` + acesso direto para evitar o ValueError de pd.notna() sobre listas.
+    if "entities" in row and row["entities"] is not None:
+        for field_name, values in extract_entity_fields(row["entities"]).items():
+            doc[field_name] = values
 
     # Campo de embedding (vetor de floats para busca semântica)
     if "content_embedding" in row and row["content_embedding"] is not None:

--- a/src/data_platform/workers/typesense_sync/handler.py
+++ b/src/data_platform/workers/typesense_sync/handler.py
@@ -54,6 +54,10 @@ _GRAPHQL_TO_SNAKE: dict[str, str] = {
     "readabilityFlesch": "readability_flesch",
 }
 
+# Feature keys (dentro do JSON `features`) que prepare_document consome diretamente.
+# entities → lista de {text, type, count}; view_count → int.
+_FEATURES_PASSTHROUGH: tuple[str, ...] = ("entities", "view_count")
+
 
 def _parse_iso_to_epoch(iso_str: str | None) -> int:
     """Convert an ISO-8601 datetime string to a Unix epoch integer."""
@@ -77,6 +81,15 @@ def _map_graphql_row(gql_row: dict) -> dict:
     for gql_key, snake_key in _GRAPHQL_TO_SNAKE.items():
         if gql_key in gql_row and gql_row[gql_key] is not None:
             mapped[snake_key] = gql_row[gql_key]
+
+    # Extrai entidades e view_count do JSON `features` (não expostos como campos
+    # escalares pelo schema graphql; chegam dentro do blob `features`).
+    features = gql_row.get("features")
+    if isinstance(features, dict):
+        for key in _FEATURES_PASSTHROUGH:
+            value = features.get(key)
+            if value is not None:
+                mapped[key] = value
 
     # Convert ISO datetime strings to epoch timestamps (prepare_document expects these)
     if "published_at" in mapped:

--- a/tests/unit/typesense/test_collection.py
+++ b/tests/unit/typesense/test_collection.py
@@ -46,6 +46,25 @@ class TestCollectionSchema:
         )
         assert pub_field["type"] == "int64"
 
+    def test_schema_has_entity_fields(self):
+        """Schema includes combined + per-type entity fields as facetable string[]."""
+        fields = {f["name"]: f for f in COLLECTION_SCHEMA["fields"]}
+        for name in ("entities", "entity_org", "entity_per", "entity_loc", "entity_misc"):
+            assert name in fields, f"missing entity field {name}"
+            assert fields[name]["type"] == "string[]"
+            assert fields[name]["facet"] is True
+            assert fields[name]["optional"] is True
+
+    def test_schema_has_view_count_sortable(self):
+        """view_count is an optional, sortable int32."""
+        fields = {f["name"]: f for f in COLLECTION_SCHEMA["fields"]}
+        assert "view_count" in fields
+        vc = fields["view_count"]
+        assert vc["type"] == "int32"
+        assert vc["optional"] is True
+        assert vc["sort"] is True
+        assert vc["facet"] is False
+
 
 class TestCreateCollection:
     """Tests for create_collection() function."""

--- a/tests/unit/typesense/test_indexer.py
+++ b/tests/unit/typesense/test_indexer.py
@@ -15,6 +15,7 @@ import pytest
 from data_platform.typesense.indexer import (
     MAX_TAG_LENGTH,
     clean_tags,
+    extract_entity_fields,
     parse_embedding,
     prepare_document,
 )
@@ -135,6 +136,117 @@ class TestParseEmbedding:
         assert result is None
 
 
+class TestExtractEntityFields:
+    """Tests for extract_entity_fields() function."""
+
+    def test_maps_known_types_to_buckets(self):
+        """ORG/PER/LOC map to their dedicated fields."""
+        entities = [
+            {"text": "Ministério da Saúde", "type": "ORG", "count": 3},
+            {"text": "Lula", "type": "PER", "count": 2},
+            {"text": "Brasília", "type": "LOC", "count": 1},
+        ]
+        result = extract_entity_fields(entities)
+        assert result["entity_org"] == ["Ministério da Saúde"]
+        assert result["entity_per"] == ["Lula"]
+        assert result["entity_loc"] == ["Brasília"]
+
+    def test_combined_entities_contains_all_texts(self):
+        """`entities` carries every text across types."""
+        entities = [
+            {"text": "Ministério da Saúde", "type": "ORG"},
+            {"text": "Lula", "type": "PER"},
+            {"text": "Brasília", "type": "LOC"},
+        ]
+        result = extract_entity_fields(entities)
+        assert result["entities"] == ["Ministério da Saúde", "Lula", "Brasília"]
+
+    def test_misc_event_program_go_to_entity_misc(self):
+        """MISC, EVENT and PROGRAM all fall into entity_misc."""
+        entities = [
+            {"text": "Bolsa Família", "type": "PROGRAM"},
+            {"text": "Copa do Mundo", "type": "EVENT"},
+            {"text": "Algo", "type": "MISC"},
+        ]
+        result = extract_entity_fields(entities)
+        assert result["entity_misc"] == ["Bolsa Família", "Copa do Mundo", "Algo"]
+        assert "entity_org" not in result
+
+    def test_dedup_preserves_order(self):
+        """Duplicate texts are removed, first-seen order preserved."""
+        entities = [
+            {"text": "INSS", "type": "ORG"},
+            {"text": "INSS", "type": "ORG"},
+            {"text": "Caixa", "type": "ORG"},
+        ]
+        result = extract_entity_fields(entities)
+        assert result["entity_org"] == ["INSS", "Caixa"]
+        assert result["entities"] == ["INSS", "Caixa"]
+
+    def test_unknown_type_defaults_to_misc(self):
+        """Entities without a recognized type bucket into entity_misc."""
+        entities = [{"text": "Algo", "type": "WEIRD"}]
+        result = extract_entity_fields(entities)
+        assert result["entity_misc"] == ["Algo"]
+
+    def test_missing_type_defaults_to_misc(self):
+        """Entities with no type key bucket into entity_misc."""
+        entities = [{"text": "Algo"}]
+        result = extract_entity_fields(entities)
+        assert result["entity_misc"] == ["Algo"]
+
+    def test_skips_empty_and_non_string_text(self):
+        """Empty, whitespace, or non-string text values are skipped."""
+        entities = [
+            {"text": "  ", "type": "ORG"},
+            {"text": "", "type": "ORG"},
+            {"text": 123, "type": "ORG"},
+            {"text": "Válido", "type": "ORG"},
+        ]
+        result = extract_entity_fields(entities)
+        assert result["entity_org"] == ["Válido"]
+
+    def test_strips_whitespace(self):
+        """Entity text is stripped."""
+        entities = [{"text": "  Anvisa  ", "type": "ORG"}]
+        result = extract_entity_fields(entities)
+        assert result["entity_org"] == ["Anvisa"]
+
+    def test_type_is_case_insensitive(self):
+        """Lowercase type strings still map correctly."""
+        entities = [{"text": "Lula", "type": "per"}]
+        result = extract_entity_fields(entities)
+        assert result["entity_per"] == ["Lula"]
+
+    def test_empty_list_returns_empty_dict(self):
+        """Empty entity list yields no fields."""
+        assert extract_entity_fields([]) == {}
+
+    def test_none_returns_empty_dict(self):
+        """None yields no fields."""
+        assert extract_entity_fields(None) == {}
+
+    def test_non_list_returns_empty_dict(self):
+        """Non-list input yields no fields."""
+        assert extract_entity_fields({"text": "x"}) == {}
+
+    def test_json_string_is_parsed(self):
+        """A JSON-encoded string (e.g. from JSONB driver) is parsed."""
+        entities = json.dumps([{"text": "Anvisa", "type": "ORG"}])
+        result = extract_entity_fields(entities)
+        assert result["entity_org"] == ["Anvisa"]
+
+    def test_invalid_json_string_returns_empty_dict(self):
+        """Malformed JSON string yields no fields."""
+        assert extract_entity_fields("not json") == {}
+
+    def test_skips_non_dict_items(self):
+        """Non-dict items in the list are ignored."""
+        entities = ["just a string", {"text": "Anvisa", "type": "ORG"}]
+        result = extract_entity_fields(entities)
+        assert result["entity_org"] == ["Anvisa"]
+
+
 class TestPrepareDocument:
     """Tests for prepare_document() function."""
 
@@ -227,6 +339,75 @@ class TestPrepareDocument:
 
         doc = prepare_document(row)
         assert doc["content_embedding"] == [0.1, 0.2, 0.3]
+
+    def test_prepare_document_entities(self):
+        """Entities are mapped into per-type and combined fields."""
+        row = pd.Series(
+            {
+                "unique_id": "abc123",
+                "published_at_ts": 1704067200,
+                "entities": [
+                    {"text": "Ministério da Saúde", "type": "ORG", "count": 3},
+                    {"text": "Lula", "type": "PER", "count": 2},
+                    {"text": "Brasília", "type": "LOC", "count": 1},
+                    {"text": "Bolsa Família", "type": "PROGRAM", "count": 1},
+                ],
+            }
+        )
+
+        doc = prepare_document(row)
+        assert doc["entity_org"] == ["Ministério da Saúde"]
+        assert doc["entity_per"] == ["Lula"]
+        assert doc["entity_loc"] == ["Brasília"]
+        assert doc["entity_misc"] == ["Bolsa Família"]
+        assert doc["entities"] == [
+            "Ministério da Saúde",
+            "Lula",
+            "Brasília",
+            "Bolsa Família",
+        ]
+
+    def test_prepare_document_view_count(self):
+        """view_count is coerced to int."""
+        row = pd.Series(
+            {
+                "unique_id": "abc123",
+                "published_at_ts": 1704067200,
+                "view_count": 1234,
+            }
+        )
+
+        doc = prepare_document(row)
+        assert doc["view_count"] == 1234
+        assert isinstance(doc["view_count"], int)
+
+    def test_prepare_document_no_entities_no_fields(self):
+        """No entity fields are added when entities are absent."""
+        row = pd.Series(
+            {
+                "unique_id": "abc123",
+                "published_at_ts": 1704067200,
+            }
+        )
+
+        doc = prepare_document(row)
+        for field in ("entities", "entity_org", "entity_per", "entity_loc", "entity_misc"):
+            assert field not in doc
+        assert "view_count" not in doc
+
+    def test_prepare_document_empty_entities_no_fields(self):
+        """An empty entities list adds no entity fields."""
+        row = pd.Series(
+            {
+                "unique_id": "abc123",
+                "published_at_ts": 1704067200,
+                "entities": [],
+            }
+        )
+
+        doc = prepare_document(row)
+        for field in ("entities", "entity_org", "entity_per", "entity_loc", "entity_misc"):
+            assert field not in doc
 
 
 class TestIndexDocuments:

--- a/tests/workers/test_typesense_sync_graphql.py
+++ b/tests/workers/test_typesense_sync_graphql.py
@@ -55,6 +55,15 @@ SAMPLE_GRAPHQL_RESPONSE = {
     "hasVideo": False,
     "imageBroken": False,
     "readabilityFlesch": 45.2,
+    "features": {
+        "sentiment": {"label": "positive", "score": 0.85},
+        "word_count": 350,
+        "view_count": 1234,
+        "entities": [
+            {"text": "Ministério da Saúde", "type": "ORG", "count": 3},
+            {"text": "Lula", "type": "PER", "count": 2},
+        ],
+    },
 }
 
 
@@ -98,6 +107,31 @@ class TestMapGraphqlRow:
         assert mapped["theme_1_level_1_code"] == "SAUDE"
         assert mapped["theme_1_level_2_label"] == "Saúde Pública"
         assert mapped["most_specific_theme_code"] == "SAUDE_PUBLICA"
+
+    def test_entities_extracted_from_features(self):
+        """entities are pulled out of the `features` JSON blob."""
+        mapped = _map_graphql_row(SAMPLE_GRAPHQL_RESPONSE)
+        assert mapped["entities"] == [
+            {"text": "Ministério da Saúde", "type": "ORG", "count": 3},
+            {"text": "Lula", "type": "PER", "count": 2},
+        ]
+
+    def test_view_count_extracted_from_features(self):
+        """view_count is pulled out of the `features` JSON blob."""
+        mapped = _map_graphql_row(SAMPLE_GRAPHQL_RESPONSE)
+        assert mapped["view_count"] == 1234
+
+    def test_features_blob_itself_not_kept(self):
+        """The raw `features` blob is not forwarded to prepare_document."""
+        mapped = _map_graphql_row(SAMPLE_GRAPHQL_RESPONSE)
+        assert "features" not in mapped
+
+    def test_missing_features_is_safe(self):
+        """A response with no `features` key omits entities/view_count."""
+        row = {k: v for k, v in SAMPLE_GRAPHQL_RESPONSE.items() if k != "features"}
+        mapped = _map_graphql_row(row)
+        assert "entities" not in mapped
+        assert "view_count" not in mapped
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Objetivo (Fase 0)

Indexa **entidades nomeadas** e **view_count** no Typesense para que o `graphql-api` possa filtrar/facetar por entidade (`entitySuggestions`, `ArticleFilter.entities`) e ordenar por visualizações. Até agora o documento Typesense só carregava features escalares (sentiment, trending_score, word_count, ...).

## Mudanças

| Arquivo | Mudança |
|---------|---------|
| `typesense/collection.py` | `COLLECTION_SCHEMA`: `entities`, `entity_org`, `entity_per`, `entity_loc`, `entity_misc` (`string[]`, facetáveis, opcionais) + `view_count` (`int32`, opcional, sortable) |
| `typesense/indexer.py` | `extract_entity_fields()` mapeia `[{text,type,count}]` → buckets por tipo (ORG/PER/LOC dedicados; MISC/EVENT/PROGRAM/demais → `entity_misc`) + lista combinada `entities` com dedup preservando ordem; `prepare_document()` popula `entities` + `view_count` **só quando há dado** |
| `workers/typesense_sync/handler.py` | `_map_graphql_row()` extrai `entities`/`view_count` do blob `features` da resposta GraphQL |
| `clients/graphql_client.py` | `NEWS_FOR_TYPESENSE_QUERY` passa a pedir `features` |
| `managers/postgres_manager.py` | `_build_typesense_query()` faz SELECT de `view_count` e `entities` (caminho PG/fallback) |

## Como as entidades chegam ao `prepare_document` (caminho confirmado)

As entidades vivem em `news_features.features.entities = [{text, type, count}]` e `view_count` em `features.view_count`. O `TypesenseDocRecordType` do graphql-api **já expõe** o campo `features: JSON` (blob completo) — o worker simplesmente não o pedia. Solução **inteiramente no lado data-platform** (sem tocar no graphql-api):

- **GraphQL (preferencial):** a query agora pede `features`; `_map_graphql_row` extrai `features.entities` e `features.view_count` e os coloca no dict que o `prepare_document` consome.
- **PostgreSQL (fallback):** a SQL do typesense seleciona `(nf.features->>'view_count')::int` e `nf.features->'entities'`.

## Testes & lint

- `pytest tests/unit/typesense tests/workers/test_typesense_sync_graphql.py tests/unit/workers/typesense_sync tests/regression/test_d1.py` → **112 passed** (rodado no venv Python 3.12).
- Novos testes: `extract_entity_fields` (tipos/dedup/MISC/JSON-string/edge cases), `prepare_document` (entidades + view_count + ausência de dado), `COLLECTION_SCHEMA` (campos novos), `_map_graphql_row` (extração do blob `features`).
- `ruff check` / `ruff format` / `mypy`: **zero erros novos** nos arquivos tocados (a dívida de lint pré-existente do repo permanece intocada — fora de escopo).

## Comandos de reindex pós-merge (NÃO executados — disparar manualmente depois)

```bash
# 1. Atualiza o schema da coleção (adiciona os campos novos via PATCH atômico)
gh workflow run typesense-schema-update.yaml

# 2. Re-sincroniza os documentos para popular entities/view_count
gh workflow run typesense-maintenance-sync.yaml
```

> O `update_schema()` só adiciona campos faltantes; **não** popula valores em documentos existentes — por isso o maintenance-sync é necessário depois.

## Decisões / riscos

- **Match de entidade é exato por texto bruto (v1)** — sem normalização/canonicalização/deduplicação por similaridade. Variações ("MEC" vs "Ministério da Educação") contam como facets distintos. Aceitável para o v1; normalização fica para iteração futura.
- `entity_misc` agrega MISC + EVENT + PROGRAM + quaisquer tipos não mapeados.
- JSONB de `entities` é parseado mesmo se o driver entregar como string (robustez no caminho PG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)