### PR TITLE
Evolução do identificador de entidades (NER): fundação canônica, Typesense e lente semântica (#178)

### DIFF
--- a/feature_registry.yaml
+++ b/feature_registry.yaml
@@ -73,7 +73,10 @@ features:
   annotations_source_hash:
     version: "1.0"
     type: string
-    description: "Hash idempotência das entradas de content_annotations (content + surfaces)"
+    description: >-
+      Hash de idempotência das entradas de content_annotations (content +
+      surfaces); o feature-worker pula o recálculo quando este hash não muda
+      e content_annotations já existe na linha.
     model: "local/python"
     compute: "feature-worker"
 

--- a/feature_registry.yaml
+++ b/feature_registry.yaml
@@ -60,6 +60,23 @@ features:
     model: "local/textstat"
     compute: "feature-worker"
 
+  content_annotations:
+    version: "1.0"
+    type: array
+    description: >-
+      Lente semântica: offsets determinísticos das menções de entidades no
+      content [{start, end, type, text, canonical_id}], sem aninhamento
+      (longest-match-wins). Derivado de features.entities.
+    model: "local/python"
+    compute: "feature-worker"
+
+  annotations_source_hash:
+    version: "1.0"
+    type: string
+    description: "Hash idempotência das entradas de content_annotations (content + surfaces)"
+    model: "local/python"
+    compute: "feature-worker"
+
   # --- Fase 1: Features IA (extensão do enrichment) ---
   sentiment:
     version: "1.0"

--- a/scripts/migrations/015_create_entity_registry.sql
+++ b/scripts/migrations/015_create_entity_registry.sql
@@ -1,0 +1,49 @@
+-- 015_create_entity_registry.sql
+-- Registro canonico de entidades (nivel "canonico" cross-artigo, projetavel para grafo Neo4j).
+-- Cada linha = um no de entidade unica. QID do Wikidata quando linkado; senao "dgb_<slug-ou-ulid>".
+-- Ref: data-platform#178 (Evolucao do identificador de entidades / NER) — Fase 1.
+
+-- Extensao pg_trgm: necessaria para o indice trigram de matching fuzzy em canonical_name.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE TABLE IF NOT EXISTS entity_registry (
+    entity_id      VARCHAR(64) PRIMARY KEY,           -- QID ("Q216330") se linkado, senao "dgb_<slug-or-ulid>"
+    canonical_name TEXT NOT NULL,
+    type           VARCHAR(16) NOT NULL,              -- ORG|PER|LOC|EVENT|POLICY|LAW
+    aliases        JSONB NOT NULL DEFAULT '[]',
+    wikidata_id    VARCHAR(32),
+    wikidata_url   TEXT,
+    description    TEXT,
+    agency_key     VARCHAR(100) REFERENCES agencies(key),
+    confidence     REAL NOT NULL DEFAULT 0.0,
+    provenance     VARCHAR(24) NOT NULL,              -- 'agencies_seed'|'wikidata'|'llm'|'manual'
+    extra          JSONB NOT NULL DEFAULT '{}',       -- country, parent_qid, instance_of
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indices de lookup
+CREATE INDEX IF NOT EXISTS idx_entity_registry_type        ON entity_registry (type);
+CREATE INDEX IF NOT EXISTS idx_entity_registry_wikidata_id ON entity_registry (wikidata_id);
+CREATE INDEX IF NOT EXISTS idx_entity_registry_agency_key  ON entity_registry (agency_key);
+
+-- GIN em aliases (consulta de membership no array JSONB de formas alternativas)
+CREATE INDEX IF NOT EXISTS idx_entity_registry_aliases_gin ON entity_registry USING GIN (aliases);
+
+-- GIN trigram em canonical_name (matching fuzzy / similaridade textual)
+CREATE INDEX IF NOT EXISTS idx_entity_registry_name_trgm
+    ON entity_registry USING GIN (canonical_name gin_trgm_ops);
+
+-- Trigger para atualizar updated_at automaticamente
+CREATE OR REPLACE FUNCTION update_entity_registry_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER trg_entity_registry_updated_at
+    BEFORE UPDATE ON entity_registry
+    FOR EACH ROW
+    EXECUTE FUNCTION update_entity_registry_updated_at();

--- a/scripts/migrations/015_create_entity_registry_rollback.sql
+++ b/scripts/migrations/015_create_entity_registry_rollback.sql
@@ -1,0 +1,9 @@
+-- 015_create_entity_registry_rollback.sql
+-- Rollback: remove entity_registry e objetos relacionados.
+-- NOTA: NAO removemos a extensao pg_trgm aqui — outras tabelas/indices podem depender dela.
+--       Deixe-a instalada de proposito.
+
+DROP TRIGGER IF EXISTS trg_entity_registry_updated_at ON entity_registry;
+DROP FUNCTION IF EXISTS update_entity_registry_updated_at();
+-- Os indices (idx_entity_registry_*) sao removidos automaticamente com o DROP TABLE.
+DROP TABLE IF EXISTS entity_registry;

--- a/scripts/migrations/016_create_entity_alias.sql
+++ b/scripts/migrations/016_create_entity_alias.sql
@@ -1,0 +1,17 @@
+-- 016_create_entity_alias.sql
+-- Mapa de alias -> canonico: o resolver determinístico cacheado (coracao do "reprocessavel-sem-LLM").
+-- Mencao nova -> normaliza -> lookup em entity_alias[alias_norm, type]; hit anexa entity_id sem LLM.
+-- Ref: data-platform#178 (Evolucao do identificador de entidades / NER) — Fase 1.
+
+CREATE TABLE IF NOT EXISTS entity_alias (
+    alias_norm  TEXT NOT NULL,                 -- forma de superficie normalizada (ver §normalization)
+    type        VARCHAR(16) NOT NULL,
+    entity_id   VARCHAR(64) NOT NULL REFERENCES entity_registry(entity_id) ON DELETE CASCADE,
+    source      VARCHAR(24) NOT NULL,          -- 'agencies_seed'|'llm'|'wikidata'|'manual'
+    confidence  REAL NOT NULL DEFAULT 1.0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (alias_norm, type)
+);
+
+-- Indice para resolver "todos os alias de uma entidade" e suportar o ON DELETE CASCADE
+CREATE INDEX IF NOT EXISTS idx_entity_alias_entity_id ON entity_alias (entity_id);

--- a/scripts/migrations/016_create_entity_alias_rollback.sql
+++ b/scripts/migrations/016_create_entity_alias_rollback.sql
@@ -1,0 +1,4 @@
+-- 016_create_entity_alias_rollback.sql
+-- Rollback: remove a tabela entity_alias (o indice idx_entity_alias_entity_id vai junto).
+
+DROP TABLE IF EXISTS entity_alias;

--- a/scripts/migrations/017_seed_entity_registry_from_agencies.py
+++ b/scripts/migrations/017_seed_entity_registry_from_agencies.py
@@ -24,12 +24,23 @@ Both inserts use ON CONFLICT DO NOTHING, so the migration is re-runnable.
 The alias-extraction and normalize() helpers are module-level pure functions so
 they can be unit-tested in isolation.
 
+Cross-entity alias collisions: ``entity_alias`` has PK ``(alias_norm, type)`` and
+is the deterministic cross-entity resolver. If a surface form normalizes to the
+same key for MORE THAN ONE distinct entity (e.g. "Casa Civil da Presidência da
+República" shared by keys ``casacivil`` and ``planalto``), it is genuinely
+ambiguous and is inserted for NEITHER entity — all rows for that key are dropped
+and reported (``alias_collisions``) so the mention is later forced to the
+LLM / needs_review path instead of being silently misresolved. The per-entity
+``entity_registry.aliases`` JSONB stays intact for both entities (display field).
+
 Ref: data-platform#178 (Evolucao do identificador de entidades / NER) — Fase 1.
 """
 
 import re
 import time
 import unicodedata
+
+from loguru import logger
 
 PROVENANCE = "agencies_seed"
 SOURCE = "agencies_seed"
@@ -122,33 +133,58 @@ def _fetch_agencies(conn):
 
 
 def _build_rows(agencies):
-    """Build (entity_rows, alias_rows) tuples from agency rows.
+    """Build (entity_rows, alias_rows, collisions) from agency rows.
 
     entity_rows: (entity_id, canonical_name, type, aliases_list, agency_key, parent_key)
-    alias_rows:  (alias_norm, type, entity_id)
+    alias_rows:  (alias_norm, type, entity_id)  — ONLY unambiguous keys
+    collisions:  sorted list of (alias_norm, type) keys that map to >1 distinct
+                 entity_id and were therefore excluded from alias_rows entirely.
+
+    The entity_alias table is the cross-entity deterministic resolver: an
+    (alias_norm, type) is a unique key, so it can only point to one entity. A
+    surface form that normalizes to the same key across DIFFERENT entities is
+    genuinely ambiguous and must resolve to NEITHER — we drop ALL rows for that
+    key so the mention is forced to the LLM / needs_review path later, instead
+    of silently (and wrongly) being awarded to whichever entity sorts first.
+
+    The per-entity ``entity_registry.aliases`` JSONB list is left intact for
+    every entity — it is a display/provenance field, not the resolver.
     """
     entity_rows = []
-    alias_rows = []
-    seen_alias_keys: set[tuple[str, str]] = set()
+    # (alias_norm, type) -> ordered list of distinct entity_ids claiming it
+    owners: dict[tuple[str, str], list[str]] = {}
 
     for key, name, _type, parent_key in agencies:
         entity_id = f"{ENTITY_ID_PREFIX}{key}"
         aliases = extract_aliases(name, key)
         entity_rows.append((entity_id, name, ENTITY_TYPE, aliases, key, parent_key))
 
+        seen_for_entity: set[tuple[str, str]] = set()
         for alias in aliases:
             alias_norm = normalize(alias)
             if not alias_norm:
                 continue
             dedup_key = (alias_norm, ENTITY_TYPE)
-            # entity_alias PK is (alias_norm, type); dedup within this batch so we
-            # don't send conflicting rows for the same key in one execute_batch.
-            if dedup_key in seen_alias_keys:
+            # Within a single entity the same key may surface from several forms
+            # (e.g. name == key); count the entity only once per key.
+            if dedup_key in seen_for_entity:
                 continue
-            seen_alias_keys.add(dedup_key)
-            alias_rows.append((alias_norm, ENTITY_TYPE, entity_id))
+            seen_for_entity.add(dedup_key)
+            owner_list = owners.setdefault(dedup_key, [])
+            if entity_id not in owner_list:
+                owner_list.append(entity_id)
 
-    return entity_rows, alias_rows
+    alias_rows = []
+    collisions = []
+    for (alias_norm, atype), owner_ids in owners.items():
+        if len(owner_ids) > 1:
+            # Ambiguous across distinct entities -> resolve to NEITHER.
+            collisions.append((alias_norm, atype))
+            continue
+        alias_rows.append((alias_norm, atype, owner_ids[0]))
+
+    collisions.sort()
+    return entity_rows, alias_rows, collisions
 
 
 # =============================================================================
@@ -171,13 +207,27 @@ def migrate(conn, dry_run: bool = False) -> dict:
     import json
 
     agencies = _fetch_agencies(conn)
-    entity_rows, alias_rows = _build_rows(agencies)
+    entity_rows, alias_rows, collisions = _build_rows(agencies)
+
+    # Surface ambiguous surface forms that were excluded from the resolver so they
+    # land in migration_history.execution_details and the logs (never drop silently).
+    collisions_payload = [[alias_norm, atype] for (alias_norm, atype) in collisions]
+    if collisions:
+        logger.warning(
+            f"{len(collisions)} alias(es) ambiguo(s) across distinct entities — "
+            f"excluidos de entity_alias (resolvem para NENHUMA entidade, vao para LLM/needs_review): "
+            f"{collisions_payload}"
+        )
+    else:
+        logger.info("Nenhuma colisao de alias entre entidades distintas.")
 
     if dry_run:
         return {
             "agencies": len(agencies),
             "entities_to_insert": len(entity_rows),
             "aliases_to_insert": len(alias_rows),
+            "alias_collisions": collisions_payload,
+            "alias_collisions_dropped": len(collisions),
             "preview": True,
         }
 
@@ -233,6 +283,8 @@ def migrate(conn, dry_run: bool = False) -> dict:
         "agencies": len(agencies),
         "entities_inserted": len(entity_rows),
         "aliases_inserted": len(alias_rows),
+        "alias_collisions": collisions_payload,
+        "alias_collisions_dropped": len(collisions),
         "elapsed_seconds": round(elapsed, 2),
     }
 

--- a/scripts/migrations/017_seed_entity_registry_from_agencies.py
+++ b/scripts/migrations/017_seed_entity_registry_from_agencies.py
@@ -1,0 +1,269 @@
+"""
+Seed entity_registry + entity_alias from the agencies master table.
+
+Python migration following the runner interface (describe/migrate/rollback),
+mirroring 006_migrate_unique_ids.py.
+
+For each agency row (key, name, type, parent_key) it idempotently inserts:
+  - one entity_registry row:
+        entity_id    = 'dgb_' + key
+        canonical_name = name
+        type         = 'ORG'
+        agency_key   = key
+        provenance   = 'agencies_seed'
+        confidence   = 1.0
+        aliases      = JSON array of distinct surface forms
+                       {name, key, trailing-parenthetical acronym, name-without-parenthetical}
+  - one entity_alias row per alias:
+        alias_norm   = normalize(alias)
+        type         = 'ORG'
+        entity_id    = 'dgb_' + key
+        source       = 'agencies_seed'
+
+Both inserts use ON CONFLICT DO NOTHING, so the migration is re-runnable.
+The alias-extraction and normalize() helpers are module-level pure functions so
+they can be unit-tested in isolation.
+
+Ref: data-platform#178 (Evolucao do identificador de entidades / NER) — Fase 1.
+"""
+
+import re
+import time
+import unicodedata
+
+PROVENANCE = "agencies_seed"
+SOURCE = "agencies_seed"
+ENTITY_TYPE = "ORG"
+ENTITY_ID_PREFIX = "dgb_"
+
+# Matches a trailing parenthetical group, e.g. "Ministério da Educação (MEC)".
+_TRAILING_PAREN_RE = re.compile(r"\s*\(([^()]*)\)\s*$")
+
+
+# =============================================================================
+# Pure helpers (unit-tested)
+# =============================================================================
+
+
+def normalize(s: str | None) -> str:
+    """Normalize a surface form into a text key.
+
+    NFKD -> drop non-ASCII -> lowercase -> collapse internal whitespace -> strip.
+    Spaces are preserved (this is a text key, not a slug).
+    """
+    if not s:
+        return ""
+    s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii")
+    s = s.lower()
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def extract_parenthetical(name: str | None) -> str | None:
+    """Return the content of a trailing parenthetical (e.g. the acronym), or None."""
+    if not name:
+        return None
+    match = _TRAILING_PAREN_RE.search(name)
+    if not match:
+        return None
+    inner = match.group(1).strip()
+    return inner or None
+
+
+def strip_parenthetical(name: str | None) -> str:
+    """Return the name with a trailing parenthetical removed; no-op if absent."""
+    if not name:
+        return ""
+    return _TRAILING_PAREN_RE.sub("", name).strip()
+
+
+def extract_aliases(name: str | None, key: str | None) -> list[str]:
+    """Build the distinct list of surface forms for an agency.
+
+    Candidates (in stable order): full name, name-without-parenthetical,
+    trailing-parenthetical acronym, and the agency key. Empty/whitespace forms
+    are dropped and duplicates are removed while preserving first-seen order.
+    """
+    candidates: list[str] = []
+    if name:
+        candidates.append(name)
+        stripped = strip_parenthetical(name)
+        if stripped:
+            candidates.append(stripped)
+        acronym = extract_parenthetical(name)
+        if acronym:
+            candidates.append(acronym)
+    if key:
+        candidates.append(key)
+
+    seen: set[str] = set()
+    aliases: list[str] = []
+    for c in candidates:
+        c = c.strip()
+        if not c or c in seen:
+            continue
+        seen.add(c)
+        aliases.append(c)
+    return aliases
+
+
+# =============================================================================
+# Database helpers
+# =============================================================================
+
+
+def _fetch_agencies(conn):
+    """Fetch all agency rows: (key, name, type, parent_key)."""
+    cursor = conn.cursor()
+    cursor.execute("SELECT key, name, type, parent_key FROM agencies ORDER BY key")
+    rows = cursor.fetchall()
+    cursor.close()
+    return rows
+
+
+def _build_rows(agencies):
+    """Build (entity_rows, alias_rows) tuples from agency rows.
+
+    entity_rows: (entity_id, canonical_name, type, aliases_list, agency_key, parent_key)
+    alias_rows:  (alias_norm, type, entity_id)
+    """
+    entity_rows = []
+    alias_rows = []
+    seen_alias_keys: set[tuple[str, str]] = set()
+
+    for key, name, _type, parent_key in agencies:
+        entity_id = f"{ENTITY_ID_PREFIX}{key}"
+        aliases = extract_aliases(name, key)
+        entity_rows.append((entity_id, name, ENTITY_TYPE, aliases, key, parent_key))
+
+        for alias in aliases:
+            alias_norm = normalize(alias)
+            if not alias_norm:
+                continue
+            dedup_key = (alias_norm, ENTITY_TYPE)
+            # entity_alias PK is (alias_norm, type); dedup within this batch so we
+            # don't send conflicting rows for the same key in one execute_batch.
+            if dedup_key in seen_alias_keys:
+                continue
+            seen_alias_keys.add(dedup_key)
+            alias_rows.append((alias_norm, ENTITY_TYPE, entity_id))
+
+    return entity_rows, alias_rows
+
+
+# =============================================================================
+# Runner interface
+# =============================================================================
+
+
+def describe() -> str:
+    """Human description for logs and audit."""
+    return (
+        "Semear entity_registry/entity_alias a partir da tabela agencies (provenance=agencies_seed)"
+    )
+
+
+def migrate(conn, dry_run: bool = False) -> dict:
+    """Seed entity_registry + entity_alias from agencies. Idempotent.
+
+    conn is a psycopg2 connection without autocommit (the runner manages commit).
+    """
+    import json
+
+    agencies = _fetch_agencies(conn)
+    entity_rows, alias_rows = _build_rows(agencies)
+
+    if dry_run:
+        return {
+            "agencies": len(agencies),
+            "entities_to_insert": len(entity_rows),
+            "aliases_to_insert": len(alias_rows),
+            "preview": True,
+        }
+
+    from psycopg2.extras import execute_batch
+
+    cursor = conn.cursor()
+    t0 = time.time()
+
+    entity_params = [
+        (
+            entity_id,
+            canonical_name,
+            etype,
+            json.dumps(aliases, ensure_ascii=False),
+            agency_key,
+            json.dumps({"parent_key": parent_key} if parent_key else {}, ensure_ascii=False),
+        )
+        for (entity_id, canonical_name, etype, aliases, agency_key, parent_key) in entity_rows
+    ]
+    execute_batch(
+        cursor,
+        """
+        INSERT INTO entity_registry
+            (entity_id, canonical_name, type, aliases, wikidata_id, wikidata_url,
+             description, agency_key, confidence, provenance, extra)
+        VALUES (%s, %s, %s, %s::jsonb, NULL, NULL, NULL, %s, 1.0, '"""
+        + PROVENANCE
+        + """', %s::jsonb)
+        ON CONFLICT (entity_id) DO NOTHING
+        """,
+        entity_params,
+        page_size=500,
+    )
+
+    alias_params = [
+        (alias_norm, atype, entity_id, SOURCE) for (alias_norm, atype, entity_id) in alias_rows
+    ]
+    execute_batch(
+        cursor,
+        """
+        INSERT INTO entity_alias (alias_norm, type, entity_id, source, confidence)
+        VALUES (%s, %s, %s, %s, 1.0)
+        ON CONFLICT (alias_norm, type) DO NOTHING
+        """,
+        alias_params,
+        page_size=500,
+    )
+
+    cursor.close()
+    elapsed = time.time() - t0
+
+    return {
+        "agencies": len(agencies),
+        "entities_inserted": len(entity_rows),
+        "aliases_inserted": len(alias_rows),
+        "elapsed_seconds": round(elapsed, 2),
+    }
+
+
+def rollback(conn, dry_run: bool = False) -> dict:
+    """Delete only the rows seeded by this migration (provenance/source = agencies_seed)."""
+    cursor = conn.cursor()
+
+    if dry_run:
+        cursor.execute("SELECT COUNT(*) FROM entity_alias WHERE source = %s", (SOURCE,))
+        aliases_to_delete = cursor.fetchone()[0]
+        cursor.execute("SELECT COUNT(*) FROM entity_registry WHERE provenance = %s", (PROVENANCE,))
+        entities_to_delete = cursor.fetchone()[0]
+        cursor.close()
+        return {
+            "entities_to_delete": entities_to_delete,
+            "aliases_to_delete": aliases_to_delete,
+            "preview": True,
+        }
+
+    # Delete aliases first (they FK to entity_registry; ON DELETE CASCADE would also
+    # cover registry-seeded rows, but we delete explicitly to honor the source filter).
+    cursor.execute("DELETE FROM entity_alias WHERE source = %s", (SOURCE,))
+    aliases_deleted = cursor.rowcount
+
+    cursor.execute("DELETE FROM entity_registry WHERE provenance = %s", (PROVENANCE,))
+    entities_deleted = cursor.rowcount
+
+    cursor.close()
+
+    return {
+        "entities_deleted": entities_deleted,
+        "aliases_deleted": aliases_deleted,
+    }

--- a/scripts/migrations/018_index_features_canonical.sql
+++ b/scripts/migrations/018_index_features_canonical.sql
@@ -1,0 +1,8 @@
+-- 018_index_features_canonical.sql
+-- Indice GIN (jsonb_path_ops) sobre features->'entities' para a consulta
+-- "artigos que mencionam uma entidade canonica":
+--   SELECT * FROM news_features WHERE features->'entities' @> '[{"canonical_id":"Q216330"}]'
+-- Ref: data-platform#178 (Evolucao do identificador de entidades / NER) — Fase 1.
+
+CREATE INDEX IF NOT EXISTS idx_features_entities_canonical
+    ON news_features USING GIN ((features -> 'entities') jsonb_path_ops);

--- a/scripts/migrations/018_index_features_canonical_rollback.sql
+++ b/scripts/migrations/018_index_features_canonical_rollback.sql
@@ -1,0 +1,4 @@
+-- 018_index_features_canonical_rollback.sql
+-- Rollback: remove o indice GIN de canonical_id em features->'entities'.
+
+DROP INDEX IF EXISTS idx_features_entities_canonical;

--- a/scripts/migrations/019_create_news_llm_raw.sql
+++ b/scripts/migrations/019_create_news_llm_raw.sql
@@ -1,0 +1,18 @@
+-- 019_create_news_llm_raw.sql
+-- Armazenamento append-only das respostas cruas do LLM (reprocessabilidade):
+-- permite re-parse sem re-chamar o Bedrock. prompt_hash = idempotencia / "o prompt mudou?".
+-- Ref: data-platform#178 (Evolucao do identificador de entidades / NER) — Fase 1.
+
+CREATE TABLE IF NOT EXISTS news_llm_raw (
+    id            BIGSERIAL PRIMARY KEY,
+    unique_id     VARCHAR(120) NOT NULL REFERENCES news(unique_id) ON DELETE CASCADE,
+    task          VARCHAR(32) NOT NULL,        -- 'ner'|'enrichment'|...
+    model_id      TEXT NOT NULL,
+    prompt_version VARCHAR(32) NOT NULL,
+    prompt_hash   CHAR(64) NOT NULL,
+    raw_response  JSONB NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_news_llm_raw_unique_id_task ON news_llm_raw (unique_id, task);
+CREATE INDEX IF NOT EXISTS idx_news_llm_raw_prompt_version ON news_llm_raw (prompt_version);

--- a/scripts/migrations/019_create_news_llm_raw_rollback.sql
+++ b/scripts/migrations/019_create_news_llm_raw_rollback.sql
@@ -1,0 +1,4 @@
+-- 019_create_news_llm_raw_rollback.sql
+-- Rollback: remove a tabela news_llm_raw (os indices idx_news_llm_raw_* vao junto).
+
+DROP TABLE IF EXISTS news_llm_raw;

--- a/scripts/migrations/020_create_entity_registry_seen.sql
+++ b/scripts/migrations/020_create_entity_registry_seen.sql
@@ -1,0 +1,36 @@
+-- 020_create_entity_registry_seen.sql
+-- Estado da canonicalizacao por forma-de-superficie distinta (resumibilidade + auditoria).
+-- O job de canonicalizacao (data-science) varre formas distintas de news_features, resolve
+-- cada (surface_norm, type) uma unica vez e registra o resultado aqui para nao re-tentar
+-- indefinidamente as que ficaram em 'needs_review'. Ref: data-platform#178 — Fase 3.
+
+CREATE TABLE IF NOT EXISTS entity_registry_seen (
+    surface_norm     TEXT NOT NULL,                  -- normalize(forma_canonica) — chave do resolver
+    type             VARCHAR(16) NOT NULL,           -- ORG|PER|LOC|EVENT|POLICY|LAW
+    status           VARCHAR(16) NOT NULL DEFAULT 'pending'
+                       CHECK (status IN ('pending', 'resolved', 'needs_review')),
+    entity_id        VARCHAR(64) REFERENCES entity_registry(entity_id) ON DELETE SET NULL,
+    attempts         INTEGER NOT NULL DEFAULT 0,
+    sample_unique_id VARCHAR(120),                   -- artigo exemplo (p/ escalada contextual de PER)
+    last_error       TEXT,
+    first_seen_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (surface_norm, type)
+);
+
+-- Indice para varrer as pendentes/needs_review rapidamente
+CREATE INDEX IF NOT EXISTS idx_entity_registry_seen_status ON entity_registry_seen (status);
+
+-- Trigger para atualizar updated_at automaticamente
+CREATE OR REPLACE FUNCTION update_entity_registry_seen_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER trg_entity_registry_seen_updated_at
+    BEFORE UPDATE ON entity_registry_seen
+    FOR EACH ROW
+    EXECUTE FUNCTION update_entity_registry_seen_updated_at();

--- a/scripts/migrations/020_create_entity_registry_seen_rollback.sql
+++ b/scripts/migrations/020_create_entity_registry_seen_rollback.sql
@@ -1,0 +1,4 @@
+-- Rollback de 020_create_entity_registry_seen.sql
+DROP TRIGGER IF EXISTS trg_entity_registry_seen_updated_at ON entity_registry_seen;
+DROP FUNCTION IF EXISTS update_entity_registry_seen_updated_at();
+DROP TABLE IF EXISTS entity_registry_seen;

--- a/src/data_platform/typesense/collection.py
+++ b/src/data_platform/typesense/collection.py
@@ -107,13 +107,18 @@ COLLECTION_SCHEMA: dict[str, Any] = {
         {"name": "has_video", "type": "bool", "facet": True, "optional": True},
         {"name": "image_broken", "type": "bool", "facet": True, "optional": True},
         {"name": "readability_flesch", "type": "float", "facet": False, "optional": True},
-        # Named entities (from news_features.features.entities: [{text, type, count}])
+        # Named entities (from news_features.features.entities:
+        # [{text, type, count, canonical_id}]).
         # `entities` carries all entity texts (any type); `entity_*` are per-type buckets.
+        # `entity_canonical` carries the deduped canonical_id list for facet-by-canonical.
         {"name": "entities", "type": "string[]", "facet": True, "optional": True},
         {"name": "entity_org", "type": "string[]", "facet": True, "optional": True},
         {"name": "entity_per", "type": "string[]", "facet": True, "optional": True},
         {"name": "entity_loc", "type": "string[]", "facet": True, "optional": True},
+        {"name": "entity_event", "type": "string[]", "facet": True, "optional": True},
+        {"name": "entity_policy", "type": "string[]", "facet": True, "optional": True},
         {"name": "entity_misc", "type": "string[]", "facet": True, "optional": True},
+        {"name": "entity_canonical", "type": "string[]", "facet": True, "optional": True},
         # Engagement (from news_features.features.view_count)
         {"name": "view_count", "type": "int32", "facet": False, "optional": True, "sort": True},
         # Embedding field for semantic search (768 dimensions - BGE-M3)

--- a/src/data_platform/typesense/indexer.py
+++ b/src/data_platform/typesense/indexer.py
@@ -18,11 +18,13 @@ logger = logging.getLogger(__name__)
 MAX_TAG_LENGTH = 100
 
 # Mapeamento de tipo de entidade (news_features.features.entities) → campo Typesense.
-# Tipos não listados (MISC, EVENT, PROGRAM, ...) caem em entity_misc.
+# Tipos não listados (LAW, WORK, PRODUCT, MISC, ...) caem em entity_misc.
 _ENTITY_TYPE_TO_FIELD: dict[str, str] = {
     "ORG": "entity_org",
     "PER": "entity_per",
     "LOC": "entity_loc",
+    "EVENT": "entity_event",
+    "POLICY": "entity_policy",
 }
 
 
@@ -49,8 +51,10 @@ def extract_entity_fields(entities_value: Any) -> dict[str, list[str]]:
         entities_value: Lista de dicts de entidades (ou None / valor inválido).
 
     Returns:
-        Dicionário com as chaves ``entities`` (todos os textos, dedup) e
-        ``entity_org``/``entity_per``/``entity_loc``/``entity_misc`` (por tipo).
+        Dicionário com as chaves ``entities`` (todos os textos, dedup),
+        ``entity_org``/``entity_per``/``entity_loc``/``entity_event``/
+        ``entity_policy``/``entity_misc`` (por tipo) e ``entity_canonical``
+        (lista ordenada e única de ``canonical_id`` não-nulos das menções).
         Chaves com lista vazia são omitidas para não popular campos sem dado.
     """
     # JSONB pode chegar como string (dependendo do driver/adaptador); tenta parsear.
@@ -67,9 +71,12 @@ def extract_entity_fields(entities_value: Any) -> dict[str, list[str]]:
         "entity_org": [],
         "entity_per": [],
         "entity_loc": [],
+        "entity_event": [],
+        "entity_policy": [],
         "entity_misc": [],
     }
     all_texts: list[str] = []
+    canonical_ids: set[str] = set()
 
     for entity in entities_value:
         if not isinstance(entity, dict):
@@ -88,6 +95,10 @@ def extract_entity_fields(entities_value: Any) -> dict[str, list[str]]:
         buckets[field].append(text)
         all_texts.append(text)
 
+        canonical_id = entity.get("canonical_id")
+        if isinstance(canonical_id, str) and canonical_id.strip():
+            canonical_ids.add(canonical_id.strip())
+
     result: dict[str, list[str]] = {}
     combined = _dedup_preserving_order(all_texts)
     if combined:
@@ -96,6 +107,8 @@ def extract_entity_fields(entities_value: Any) -> dict[str, list[str]]:
         deduped = _dedup_preserving_order(texts)
         if deduped:
             result[field] = deduped
+    if canonical_ids:
+        result["entity_canonical"] = sorted(canonical_ids)
 
     return result
 

--- a/src/data_platform/workers/feature_worker/features.py
+++ b/src/data_platform/workers/feature_worker/features.py
@@ -1,8 +1,24 @@
 """Pure feature computation functions (no I/O, easily testable)."""
 
+import hashlib
+import json
+import re
+import unicodedata
 from datetime import datetime
+from typing import Any
 
 import textstat
+
+# Word-boundary lookarounds. Python's ``\b`` is unreliable with accented
+# characters, so we assert explicitly that the match is not flanked by a
+# letter or digit (including the Latin-1 accented range À-ÿ).
+_WORD_CHAR = r"[0-9A-Za-zÀ-ÿ]"
+_BOUNDARY_BEFORE = rf"(?<!{_WORD_CHAR})"
+_BOUNDARY_AFTER = rf"(?!{_WORD_CHAR})"
+
+# Placeholder kept for characters whose per-char fold is empty, so the folded
+# string stays index-aligned (1:1) with the original content.
+_FOLD_EMPTY = "\x00"
 
 
 def compute_word_count(content: str | None) -> int:
@@ -48,6 +64,180 @@ def compute_readability_flesch(content: str | None) -> float | None:
         return round(textstat.flesch_reading_ease(content), 2)
     except Exception:
         return None
+
+
+def _strip_diacritics(text: str) -> str:
+    """Remove combining diacritical marks (NFD decomposition, drop Mn)."""
+    decomposed = unicodedata.normalize("NFD", text)
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+
+
+def _fold_char(ch: str) -> str:
+    """
+    Fold a single character to a single folded character, preserving 1:1
+    alignment with the original index.
+
+    Folding = casefold + strip diacritics. A per-character casefold/strip may
+    yield zero chars (pure combining mark) or several chars (e.g. 'ß' → 'ss');
+    we collapse to exactly one representative char so the folded string stays
+    index-aligned with the original content. ``_FOLD_EMPTY`` marks a position
+    whose fold is empty (e.g. a standalone combining mark) — it can never be
+    part of a surface match.
+    """
+    folded = _strip_diacritics(ch.casefold())
+    if not folded:
+        return _FOLD_EMPTY
+    return folded[0]
+
+
+def _fold_aligned(content: str) -> str:
+    """
+    Fold ``content`` to a same-length string (1:1 char-index map back to the
+    original). NFC first (so pre-composed accents are consistent), then fold
+    each character independently.
+    """
+    normalized = unicodedata.normalize("NFC", content)
+    return "".join(_fold_char(ch) for ch in normalized)
+
+
+def _fold_surface(text: str) -> str:
+    """
+    Fold an entity surface for matching: NFC → casefold → strip diacritics.
+    Internal whitespace is collapsed to a single space (the regex turns it into
+    ``\\s+`` so it tolerates runs of whitespace/newlines in the content).
+    """
+    folded = _strip_diacritics(unicodedata.normalize("NFC", text).casefold())
+    return re.sub(r"\s+", " ", folded).strip()
+
+
+def _surface_pattern(folded_surface: str) -> re.Pattern[str]:
+    """Build a word-boundary regex for a folded surface (whitespace → ``\\s+``)."""
+    parts = [re.escape(tok) for tok in folded_surface.split(" ")]
+    body = r"\s+".join(parts)
+    return re.compile(f"{_BOUNDARY_BEFORE}{body}{_BOUNDARY_AFTER}")
+
+
+def compute_content_annotations(
+    content: str | None, entities: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """
+    Derive deterministic inline offsets for entity mentions in ``content``.
+
+    Each entity surface (``text``) is matched against an accent/case-folded copy
+    of ``content`` that is index-aligned 1:1 with the original, so the returned
+    ``start``/``end`` are offsets into the *original* string. Matching uses
+    word-boundary lookarounds (``\\b`` is unreliable with accents) and collapses
+    internal whitespace in the surface to ``\\s+``.
+
+    Overlap resolution is **longest-match-wins, no nesting**: all candidate spans
+    are gathered, sorted by ``(start asc, length desc)`` with ties broken by
+    entity ``count`` desc then original order, then swept with a cursor that
+    accepts a span only when ``start >= cursor`` (and advances ``cursor`` to its
+    end). Thus ``Ministério da Educação (MEC)`` wins and the nested ``MEC`` is
+    dropped, while a standalone later ``MEC`` still matches.
+
+    Args:
+        content: Article body (``news.content``). None/empty → ``[]``.
+        entities: ``news_features.features.entities`` list of mention dicts.
+
+    Returns:
+        Flat, sorted, non-overlapping list of
+        ``{start, end, type, text, canonical_id}`` (canonical_id may be None).
+        Entities not found in the content contribute nothing.
+    """
+    if not content or not entities:
+        return []
+
+    folded_content = _fold_aligned(content)
+
+    # Gather all candidate spans. Each candidate carries sort keys for
+    # deterministic, idempotent overlap resolution.
+    candidates: list[dict[str, Any]] = []
+    for order, entity in enumerate(entities):
+        if not isinstance(entity, dict):
+            continue
+        text = entity.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+
+        folded_surface = _fold_surface(text)
+        if not folded_surface:
+            continue
+
+        pattern = _surface_pattern(folded_surface)
+        entity_type = entity.get("type")
+        entity_type = entity_type.strip().upper() if isinstance(entity_type, str) else None
+        canonical_id = entity.get("canonical_id")
+        if not isinstance(canonical_id, str):
+            canonical_id = None
+        count = entity.get("count")
+        count = count if isinstance(count, int) else 0
+
+        for match in pattern.finditer(folded_content):
+            start, end = match.start(), match.end()
+            # The folded copy is index-aligned, so original offsets == folded
+            # offsets. Defensive guard: a folded-empty char must not anchor a span.
+            if _FOLD_EMPTY in folded_content[start:end]:
+                continue
+            candidates.append(
+                {
+                    "start": start,
+                    "end": end,
+                    "length": end - start,
+                    "type": entity_type,
+                    "text": content[start:end],
+                    "canonical_id": canonical_id,
+                    "_count": count,
+                    "_order": order,
+                }
+            )
+
+    # Longest-match-wins sweep. Sort by start asc, then length desc, then
+    # count desc, then original entity order (stable → idempotent).
+    candidates.sort(key=lambda c: (c["start"], -c["length"], -c["_count"], c["_order"]))
+
+    annotations: list[dict[str, Any]] = []
+    cursor = 0
+    for cand in candidates:
+        if cand["start"] < cursor:
+            continue
+        annotations.append(
+            {
+                "start": cand["start"],
+                "end": cand["end"],
+                "type": cand["type"],
+                "text": cand["text"],
+                "canonical_id": cand["canonical_id"],
+            }
+        )
+        cursor = cand["end"]
+
+    return annotations
+
+
+def compute_annotations_source_hash(content: str | None, entities: list[dict[str, Any]]) -> str:
+    """
+    Cheap idempotency hash over the inputs that determine annotations.
+
+    Lets the handler skip recompute when neither content nor the entity surfaces
+    / canonical_ids changed. Hashes only the fields that affect the output.
+    """
+    surfaces = [
+        {
+            "text": e.get("text"),
+            "type": e.get("type"),
+            "canonical_id": e.get("canonical_id"),
+            "count": e.get("count"),
+        }
+        for e in entities
+        if isinstance(e, dict)
+    ]
+    payload = json.dumps(
+        {"content": content or "", "entities": surfaces},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def compute_all(article: dict) -> dict:

--- a/src/data_platform/workers/feature_worker/features.py
+++ b/src/data_platform/workers/feature_worker/features.py
@@ -16,10 +16,6 @@ _WORD_CHAR = r"[0-9A-Za-zÀ-ÿ]"
 _BOUNDARY_BEFORE = rf"(?<!{_WORD_CHAR})"
 _BOUNDARY_AFTER = rf"(?!{_WORD_CHAR})"
 
-# Placeholder kept for characters whose per-char fold is empty, so the folded
-# string stays index-aligned (1:1) with the original content.
-_FOLD_EMPTY = "\x00"
-
 
 def compute_word_count(content: str | None) -> int:
     if not content:
@@ -66,47 +62,44 @@ def compute_readability_flesch(content: str | None) -> float | None:
         return None
 
 
-def _strip_diacritics(text: str) -> str:
-    """Remove combining diacritical marks (NFD decomposition, drop Mn)."""
-    decomposed = unicodedata.normalize("NFD", text)
-    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
-
-
-def _fold_char(ch: str) -> str:
+def _fold_codepoint(ch: str) -> str:
     """
-    Fold a single character to a single folded character, preserving 1:1
-    alignment with the original index.
-
-    Folding = casefold + strip diacritics. A per-character casefold/strip may
-    yield zero chars (pure combining mark) or several chars (e.g. 'ß' → 'ss');
-    we collapse to exactly one representative char so the folded string stays
-    index-aligned with the original content. ``_FOLD_EMPTY`` marks a position
-    whose fold is empty (e.g. a standalone combining mark) — it can never be
-    part of a surface match.
+    Fold a single original codepoint: NFKD decompose → drop combining marks →
+    casefold. May expand (``'ß'`` → ``'ss'``), contract to empty (a standalone
+    combining mark), or stay 1:1. Callers must NOT assume length is preserved.
     """
-    folded = _strip_diacritics(ch.casefold())
-    if not folded:
-        return _FOLD_EMPTY
-    return folded[0]
+    decomposed = unicodedata.normalize("NFKD", ch)
+    stripped = "".join(c for c in decomposed if not unicodedata.combining(c))
+    return stripped.casefold()
 
 
-def _fold_aligned(content: str) -> str:
+def _fold_with_map(s: str) -> tuple[str, list[int]]:
     """
-    Fold ``content`` to a same-length string (1:1 char-index map back to the
-    original). NFC first (so pre-composed accents are consistent), then fold
-    each character independently.
+    Fold ``s`` for accent/case-insensitive matching, returning the folded string
+    plus a map from each folded char position back to the ORIGINAL codepoint
+    index that produced it.
+
+    Folding is per original codepoint (NFKD → drop combining → casefold), so it
+    is NOT length-preserving in either direction. The index map — not an
+    equal-length assumption — is what lets a folded match span be translated back
+    to offsets into the original (un-renormalized) string.
     """
-    normalized = unicodedata.normalize("NFC", content)
-    return "".join(_fold_char(ch) for ch in normalized)
+    folded: list[str] = []
+    idx_map: list[int] = []  # folded position -> original codepoint index
+    for i, ch in enumerate(s):
+        for fc in _fold_codepoint(ch):
+            folded.append(fc)
+            idx_map.append(i)
+    return "".join(folded), idx_map
 
 
 def _fold_surface(text: str) -> str:
     """
-    Fold an entity surface for matching: NFC → casefold → strip diacritics.
+    Fold an entity surface for matching (same per-codepoint fold as the content).
     Internal whitespace is collapsed to a single space (the regex turns it into
     ``\\s+`` so it tolerates runs of whitespace/newlines in the content).
     """
-    folded = _strip_diacritics(unicodedata.normalize("NFC", text).casefold())
+    folded, _ = _fold_with_map(text)
     return re.sub(r"\s+", " ", folded).strip()
 
 
@@ -124,10 +117,12 @@ def compute_content_annotations(
     Derive deterministic inline offsets for entity mentions in ``content``.
 
     Each entity surface (``text``) is matched against an accent/case-folded copy
-    of ``content`` that is index-aligned 1:1 with the original, so the returned
-    ``start``/``end`` are offsets into the *original* string. Matching uses
-    word-boundary lookarounds (``\\b`` is unreliable with accents) and collapses
-    internal whitespace in the surface to ``\\s+``.
+    of ``content``. Folding is per original codepoint (NFKD → drop combining →
+    casefold) and is NOT length-preserving, so an explicit folded→original index
+    map (``_fold_with_map``) translates each folded match span back to offsets
+    into the *original*, un-renormalized ``content`` — never assume equal length.
+    Matching uses word-boundary lookarounds (``\\b`` is unreliable with accents)
+    and collapses internal whitespace in the surface to ``\\s+``.
 
     Overlap resolution is **longest-match-wins, no nesting**: all candidate spans
     are gathered, sorted by ``(start asc, length desc)`` with ties broken by
@@ -143,12 +138,16 @@ def compute_content_annotations(
     Returns:
         Flat, sorted, non-overlapping list of
         ``{start, end, type, text, canonical_id}`` (canonical_id may be None).
-        Entities not found in the content contribute nothing.
+        ``start``/``end``/``text`` index the original ``content`` (the stored
+        ``text`` is exactly ``content[start:end]``). Entities not found in the
+        content contribute nothing.
     """
     if not content or not entities:
         return []
 
-    folded_content = _fold_aligned(content)
+    folded_content, idx_map = _fold_with_map(content)
+    if not folded_content:
+        return []
 
     # Gather all candidate spans. Each candidate carries sort keys for
     # deterministic, idempotent overlap resolution.
@@ -174,11 +173,14 @@ def compute_content_annotations(
         count = count if isinstance(count, int) else 0
 
         for match in pattern.finditer(folded_content):
-            start, end = match.start(), match.end()
-            # The folded copy is index-aligned, so original offsets == folded
-            # offsets. Defensive guard: a folded-empty char must not anchor a span.
-            if _FOLD_EMPTY in folded_content[start:end]:
+            fa, fb = match.start(), match.end()
+            # Empty folded match (defensive — surface fold is non-empty here, so
+            # fb > fa, but guard anyway).
+            if fb <= fa:
                 continue
+            # Map folded span [fa, fb) back to original codepoint offsets.
+            start = idx_map[fa]
+            end = idx_map[fb - 1] + 1
             candidates.append(
                 {
                     "start": start,

--- a/src/data_platform/workers/feature_worker/handler.py
+++ b/src/data_platform/workers/feature_worker/handler.py
@@ -2,27 +2,51 @@
 
 import json
 import logging
+from typing import Any
 
 from data_platform.managers.postgres_manager import PostgresManager
-from data_platform.workers.feature_worker.features import compute_all
+from data_platform.workers.feature_worker.features import (
+    compute_all,
+    compute_annotations_source_hash,
+    compute_content_annotations,
+)
 
 logger = logging.getLogger(__name__)
 
 
+def _coerce_entities(value: Any) -> list[dict[str, Any]]:
+    """Normalize a features.entities blob into a list of mention dicts."""
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+    if not isinstance(value, list):
+        return []
+    return [e for e in value if isinstance(e, dict)]
+
+
 def _fetch_article_via_graphql(unique_id: str, gql_client) -> dict | None:
-    """Fetch article fields needed for feature computation via GraphQL."""
+    """Fetch article fields needed for feature computation via GraphQL.
+
+    The `features` blob (already returned by NEWS_BY_ID_QUERY) is surfaced so the
+    handler can derive content annotations from the current entity mentions.
+    """
     from data_platform.clients.graphql_client import NEWS_BY_ID_QUERY
 
     data = gql_client.query(NEWS_BY_ID_QUERY, {"uniqueId": unique_id})
     article = data.get("newsById")
     if not article:
         return None
+    features = article.get("features")
+    entities = _coerce_entities(features.get("entities")) if isinstance(features, dict) else []
     return {
         "unique_id": article.get("uniqueId"),
         "content": article.get("content"),
         "image_url": article.get("imageUrl"),
         "video_url": article.get("videoUrl"),
         "published_at": article.get("publishedAt"),
+        "entities": entities,
     }
 
 
@@ -62,12 +86,25 @@ def handle_feature_computation(unique_id: str, pg: PostgresManager, gql_client=N
     # 2. Compute all local features
     features = compute_all(article)
 
-    # 3. Upsert features
+    # 3. Derive deterministic content annotations (semantic-lens offsets) from the
+    #    article's CURRENT entity mentions. If entities are absent (race with the
+    #    data-science enrichment worker that writes features.entities), emit an
+    #    empty list — a later recompute will fill it in. Never crash.
+    content = article.get("content")
+    entities = _coerce_entities(article.get("entities"))
+    annotations = compute_content_annotations(content, entities)
+    features["content_annotations"] = annotations
+    features["annotations_source_hash"] = compute_annotations_source_hash(content, entities)
+
+    # 4. Upsert features
     if gql_client:
         _upsert_features_via_graphql(unique_id, features, gql_client)
     else:
         pg.upsert_features(unique_id, features)
-    logger.info(f"Computed {len(features)} features for {unique_id}")
+    logger.info(
+        f"Computed {len(features)} features for {unique_id} "
+        f"({len(annotations)} content annotations)"
+    )
 
     return {
         "status": "computed",
@@ -77,15 +114,22 @@ def handle_feature_computation(unique_id: str, pg: PostgresManager, gql_client=N
 
 
 def _fetch_article(unique_id: str, pg: PostgresManager) -> dict | None:
-    """Fetch article fields needed for feature computation."""
+    """Fetch article fields needed for feature computation.
+
+    Also pulls the current `news_features.features.entities` so the handler can
+    derive content annotations. Entities may be absent (not yet enriched) — the
+    LEFT JOIN yields NULL and the caller treats it as no annotations.
+    """
     conn = pg.get_connection()
     try:
         cursor = conn.cursor()
         cursor.execute(
             """
-            SELECT unique_id, content, image_url, video_url, published_at
-            FROM news
-            WHERE unique_id = %s
+            SELECT n.unique_id, n.content, n.image_url, n.video_url, n.published_at,
+                   nf.features->'entities' AS entities
+            FROM news n
+            LEFT JOIN news_features nf ON n.unique_id = nf.unique_id
+            WHERE n.unique_id = %s
             """,
             (unique_id,),
         )
@@ -98,6 +142,7 @@ def _fetch_article(unique_id: str, pg: PostgresManager) -> dict | None:
             "image_url": row[2],
             "video_url": row[3],
             "published_at": row[4],
+            "entities": _coerce_entities(row[5]),
         }
     finally:
         cursor.close()

--- a/src/data_platform/workers/feature_worker/handler.py
+++ b/src/data_platform/workers/feature_worker/handler.py
@@ -38,8 +38,8 @@ def _fetch_article_via_graphql(unique_id: str, gql_client) -> dict | None:
     article = data.get("newsById")
     if not article:
         return None
-    features = article.get("features")
-    entities = _coerce_entities(features.get("entities")) if isinstance(features, dict) else []
+    features = article.get("features") if isinstance(article.get("features"), dict) else {}
+    entities = _coerce_entities(features.get("entities"))
     return {
         "unique_id": article.get("uniqueId"),
         "content": article.get("content"),
@@ -47,6 +47,8 @@ def _fetch_article_via_graphql(unique_id: str, gql_client) -> dict | None:
         "video_url": article.get("videoUrl"),
         "published_at": article.get("publishedAt"),
         "entities": entities,
+        "existing_annotations_hash": features.get("annotations_source_hash"),
+        "has_content_annotations": "content_annotations" in features,
     }
 
 
@@ -90,26 +92,45 @@ def handle_feature_computation(unique_id: str, pg: PostgresManager, gql_client=N
     #    article's CURRENT entity mentions. If entities are absent (race with the
     #    data-science enrichment worker that writes features.entities), emit an
     #    empty list — a later recompute will fill it in. Never crash.
+    #
+    #    Skip the (re)derivation when the inputs are unchanged: the stored
+    #    annotations_source_hash matches the freshly computed hash AND a
+    #    content_annotations key already exists in the row. The other local
+    #    features are still recomputed + upserted (cheap, content-driven).
     content = article.get("content")
     entities = _coerce_entities(article.get("entities"))
-    annotations = compute_content_annotations(content, entities)
-    features["content_annotations"] = annotations
-    features["annotations_source_hash"] = compute_annotations_source_hash(content, entities)
+    new_hash = compute_annotations_source_hash(content, entities)
+    hash_matches = article.get("existing_annotations_hash") == new_hash
+    has_existing = bool(article.get("has_content_annotations"))
+    annotations_skipped = hash_matches and has_existing
+    if annotations_skipped:
+        annotations: list[dict[str, Any]] | None = None
+    else:
+        annotations = compute_content_annotations(content, entities)
+        features["content_annotations"] = annotations
+        features["annotations_source_hash"] = new_hash
 
     # 4. Upsert features
     if gql_client:
         _upsert_features_via_graphql(unique_id, features, gql_client)
     else:
         pg.upsert_features(unique_id, features)
-    logger.info(
-        f"Computed {len(features)} features for {unique_id} "
-        f"({len(annotations)} content annotations)"
-    )
+    if annotations_skipped:
+        logger.info(
+            f"Computed {len(features)} features for {unique_id} "
+            "(content_annotations unchanged — skipped)"
+        )
+    else:
+        logger.info(
+            f"Computed {len(features)} features for {unique_id} "
+            f"({len(annotations or [])} content annotations)"
+        )
 
     return {
         "status": "computed",
         "unique_id": unique_id,
         "features": list(features.keys()),
+        "annotations_skipped": annotations_skipped,
     }
 
 
@@ -126,7 +147,9 @@ def _fetch_article(unique_id: str, pg: PostgresManager) -> dict | None:
         cursor.execute(
             """
             SELECT n.unique_id, n.content, n.image_url, n.video_url, n.published_at,
-                   nf.features->'entities' AS entities
+                   nf.features->'entities' AS entities,
+                   nf.features->>'annotations_source_hash' AS annotations_source_hash,
+                   (nf.features ? 'content_annotations') AS has_content_annotations
             FROM news n
             LEFT JOIN news_features nf ON n.unique_id = nf.unique_id
             WHERE n.unique_id = %s
@@ -143,6 +166,8 @@ def _fetch_article(unique_id: str, pg: PostgresManager) -> dict | None:
             "video_url": row[3],
             "published_at": row[4],
             "entities": _coerce_entities(row[5]),
+            "existing_annotations_hash": row[6],
+            "has_content_annotations": bool(row[7]),
         }
     finally:
         cursor.close()

--- a/src/data_platform/workers/typesense_sync/handler.py
+++ b/src/data_platform/workers/typesense_sync/handler.py
@@ -55,7 +55,10 @@ _GRAPHQL_TO_SNAKE: dict[str, str] = {
 }
 
 # Feature keys (dentro do JSON `features`) que prepare_document consome diretamente.
-# entities → lista de {text, type, count}; view_count → int.
+# entities → lista de {text, type, count, canonical_id?}; view_count → int.
+# O blob `features` é exposto inteiro pela query GraphQL (e por `nf.features->'entities'`
+# no caminho PostgreSQL), portanto `canonical_id` — quando já canonicalizado — chega
+# junto sem precisar de seleção extra. extract_entity_fields() lê esse campo.
 _FEATURES_PASSTHROUGH: tuple[str, ...] = ("entities", "view_count")
 
 

--- a/tests/scripts/test_seed_entity_registry.py
+++ b/tests/scripts/test_seed_entity_registry.py
@@ -186,6 +186,93 @@ class TestMigrate017:
         # Two execute_batch calls: one for entity_registry, one for entity_alias.
         assert mock_execute_batch.call_count == 2
 
+
+# ---------------------------------------------------------------------------
+# Cross-entity alias collisions (ambiguous surface forms -> resolve to NEITHER)
+# ---------------------------------------------------------------------------
+class TestAliasCollisions:
+    # Real-world collision from agencies.yaml: two distinct keys share the same name.
+    COLLIDING_AGENCIES = [
+        ("casacivil", "Casa Civil da Presidência da República", "Órgão", "presidencia"),
+        ("planalto", "Casa Civil da Presidência da República", "Órgão", "presidencia"),
+    ]
+
+    def _build(self, mod, agencies):
+        """Call _build_rows and normalize its return into (entities, aliases, collisions)."""
+        result = mod._build_rows(agencies)
+        # _build_rows must now also surface the dropped ambiguous keys.
+        assert len(result) == 3, "_build_rows must return (entity_rows, alias_rows, collisions)"
+        return result
+
+    def test_both_registry_rows_created_despite_collision(self):
+        mod = _import_migration_017()
+        entity_rows, _alias_rows, _collisions = self._build(mod, self.COLLIDING_AGENCIES)
+        entity_ids = {row[0] for row in entity_rows}
+        # (a) BOTH entities exist in the registry.
+        assert entity_ids == {"dgb_casacivil", "dgb_planalto"}
+
+    def test_colliding_alias_inserted_for_neither(self):
+        mod = _import_migration_017()
+        _entity_rows, alias_rows, _collisions = self._build(mod, self.COLLIDING_AGENCIES)
+
+        collide_norm = mod.normalize("Casa Civil da Presidência da República")
+        # (b) The ambiguous (alias_norm, 'ORG') key is inserted for NEITHER entity.
+        for alias_norm, atype, _entity_id in alias_rows:
+            assert not (
+                alias_norm == collide_norm and atype == "ORG"
+            ), "ambiguous alias must not be inserted for any entity"
+
+        # The unambiguous keys (the agency keys themselves) survive.
+        surviving = {(a, t) for a, t, _e in alias_rows}
+        assert ("casacivil", "ORG") in surviving
+        assert ("planalto", "ORG") in surviving
+
+    def test_collision_recorded_in_build_rows(self):
+        mod = _import_migration_017()
+        _entity_rows, _alias_rows, collisions = self._build(mod, self.COLLIDING_AGENCIES)
+        collide_norm = mod.normalize("Casa Civil da Presidência da República")
+        assert [collide_norm, "ORG"] in collisions or (collide_norm, "ORG") in collisions
+
+    def test_registry_aliases_jsonb_intact_for_both(self):
+        mod = _import_migration_017()
+        entity_rows, _alias_rows, _collisions = self._build(mod, self.COLLIDING_AGENCIES)
+        # (per-entity display field is NOT pruned) — both keep the full name in their aliases.
+        by_id = {row[0]: row[3] for row in entity_rows}  # entity_id -> aliases list
+        assert "Casa Civil da Presidência da República" in by_id["dgb_casacivil"]
+        assert "Casa Civil da Presidência da República" in by_id["dgb_planalto"]
+
+    def test_single_entity_multiple_surface_forms_not_a_collision(self):
+        mod = _import_migration_017()
+        # name and key both normalize distinctly; "MEC" appears once -> 1 entity, no collision.
+        agencies = [("mec", "Ministério da Educação (MEC)", "Ministério", None)]
+        _entity_rows, alias_rows, collisions = self._build(mod, agencies)
+        assert collisions == []
+        # the alias key for the canonical name resolves to the single entity.
+        name_norm = mod.normalize("Ministério da Educação")
+        owners = {e for a, t, e in alias_rows if a == name_norm and t == "ORG"}
+        assert owners == {"dgb_mec"}
+
+    @patch("psycopg2.extras.execute_batch")
+    def test_migrate_surfaces_collisions_in_result(self, mock_execute_batch):
+        mod = _import_migration_017()
+        mock_conn, _ = _make_conn_with_agencies(self.COLLIDING_AGENCIES)
+
+        result = mod.migrate(mock_conn, dry_run=False)
+        assert result["entities_inserted"] == 2
+        assert "alias_collisions" in result
+        assert "alias_collisions_dropped" in result
+        assert result["alias_collisions_dropped"] == 1
+        collide_norm = mod.normalize("Casa Civil da Presidência da República")
+        flat = [tuple(x) if isinstance(x, list) else x for x in result["alias_collisions"]]
+        assert (collide_norm, "ORG") in flat
+
+    def test_dry_run_surfaces_collisions(self):
+        mod = _import_migration_017()
+        mock_conn, _ = _make_conn_with_agencies(self.COLLIDING_AGENCIES)
+        result = mod.migrate(mock_conn, dry_run=True)
+        assert result.get("preview") is True
+        assert result["alias_collisions_dropped"] == 1
+
     def test_rollback_returns_dict(self):
         mod = _import_migration_017()
         mock_conn = MagicMock()

--- a/tests/scripts/test_seed_entity_registry.py
+++ b/tests/scripts/test_seed_entity_registry.py
@@ -1,0 +1,212 @@
+"""Unit tests for scripts/migrations/017_seed_entity_registry_from_agencies.py.
+
+Covers the pure, module-level helpers (normalize + alias extraction) and the
+Python-migration interface (describe/migrate/rollback), mirroring test_migration_006.py.
+"""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _import_migration_017():
+    """Import the migration module dynamically (numeric prefix not importable directly)."""
+    module_path = (
+        Path(__file__).parent.parent.parent
+        / "scripts"
+        / "migrations"
+        / "017_seed_entity_registry_from_agencies.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_017", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Interface compliance
+# ---------------------------------------------------------------------------
+class TestMigration017Interface:
+    def test_describe_returns_nonempty_string(self):
+        mod = _import_migration_017()
+        result = mod.describe()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_has_migrate_function(self):
+        mod = _import_migration_017()
+        assert callable(getattr(mod, "migrate", None))
+
+    def test_has_rollback_function(self):
+        mod = _import_migration_017()
+        assert callable(getattr(mod, "rollback", None))
+
+
+# ---------------------------------------------------------------------------
+# normalize()
+# ---------------------------------------------------------------------------
+class TestNormalize:
+    def test_lowercases(self):
+        mod = _import_migration_017()
+        assert mod.normalize("MEC") == "mec"
+
+    def test_strips_accents(self):
+        mod = _import_migration_017()
+        assert mod.normalize("Educação") == "educacao"
+        assert mod.normalize("Ministério da Saúde") == "ministerio da saude"
+
+    def test_collapses_internal_whitespace(self):
+        mod = _import_migration_017()
+        assert mod.normalize("Minha   Casa,\tMinha\nVida") == "minha casa, minha vida"
+
+    def test_strips_leading_trailing_whitespace(self):
+        mod = _import_migration_017()
+        assert mod.normalize("  Finep  ") == "finep"
+
+    def test_keeps_spaces_between_words(self):
+        mod = _import_migration_017()
+        # It is a text key, not a slug — spaces are preserved.
+        assert mod.normalize("Ministério da Educação") == "ministerio da educacao"
+
+    def test_empty_and_none_safe(self):
+        mod = _import_migration_017()
+        assert mod.normalize("") == ""
+
+
+# ---------------------------------------------------------------------------
+# acronym / parenthetical helpers
+# ---------------------------------------------------------------------------
+class TestParentheticalAcronym:
+    def test_extracts_trailing_acronym(self):
+        mod = _import_migration_017()
+        assert mod.extract_parenthetical("Ministério da Educação (MEC)") == "MEC"
+
+    def test_returns_none_without_parenthesis(self):
+        mod = _import_migration_017()
+        assert mod.extract_parenthetical("Ministério da Educação") is None
+
+    def test_strips_parenthetical(self):
+        mod = _import_migration_017()
+        assert mod.strip_parenthetical("Ministério da Educação (MEC)") == "Ministério da Educação"
+
+    def test_strip_parenthetical_noop_without_parenthesis(self):
+        mod = _import_migration_017()
+        assert mod.strip_parenthetical("Finep") == "Finep"
+
+
+# ---------------------------------------------------------------------------
+# extract_aliases()
+# ---------------------------------------------------------------------------
+class TestExtractAliases:
+    def test_includes_name_key_acronym_and_stripped(self):
+        mod = _import_migration_017()
+        aliases = mod.extract_aliases("Ministério da Educação (MEC)", "mec")
+        assert "Ministério da Educação (MEC)" in aliases  # original name
+        assert "MEC" in aliases  # trailing parenthetical acronym
+        assert "Ministério da Educação" in aliases  # name with parenthetical stripped
+        assert "mec" in aliases  # the agency key
+
+    def test_no_parenthesis_yields_name_and_key(self):
+        mod = _import_migration_017()
+        aliases = mod.extract_aliases("Financiadora de Estudos e Projetos", "finep")
+        assert "Financiadora de Estudos e Projetos" in aliases
+        assert "finep" in aliases
+        # no parenthetical -> no acronym, no separate stripped form duplicated
+        assert all(a for a in aliases)  # no empty strings
+
+    def test_distinct_no_duplicates(self):
+        mod = _import_migration_017()
+        # name equal to key -> should not duplicate
+        aliases = mod.extract_aliases("Finep", "Finep")
+        assert len(aliases) == len(set(aliases))
+
+    def test_no_empty_or_whitespace_aliases(self):
+        mod = _import_migration_017()
+        aliases = mod.extract_aliases("Casa Civil ()", "casa-civil")
+        for a in aliases:
+            assert a.strip() == a
+            assert a != ""
+
+    def test_order_is_stable_and_deterministic(self):
+        mod = _import_migration_017()
+        a1 = mod.extract_aliases("Ministério da Saúde (MS)", "saude")
+        a2 = mod.extract_aliases("Ministério da Saúde (MS)", "saude")
+        assert a1 == a2
+
+
+# ---------------------------------------------------------------------------
+# migrate() / rollback() behavior with mocked connection
+# ---------------------------------------------------------------------------
+def _make_conn_with_agencies(rows):
+    """Build a mock psycopg2 conn whose first SELECT returns the given agency rows."""
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_cursor.fetchall.return_value = rows
+    return mock_conn, mock_cursor
+
+
+class TestMigrate017:
+    AGENCIES = [
+        # (key, name, type, parent_key)
+        ("mec", "Ministério da Educação (MEC)", "Ministério", None),
+        ("finep", "Financiadora de Estudos e Projetos", "Empresa", "mcti"),
+    ]
+
+    def test_dry_run_returns_counts_and_does_not_commit(self):
+        mod = _import_migration_017()
+        mock_conn, _ = _make_conn_with_agencies(self.AGENCIES)
+
+        result = mod.migrate(mock_conn, dry_run=True)
+
+        assert isinstance(result, dict)
+        assert result.get("preview") is True
+        assert result["entities_to_insert"] == 2
+        assert result["aliases_to_insert"] >= 2
+        mock_conn.commit.assert_not_called()
+
+    def test_dry_run_with_no_agencies(self):
+        mod = _import_migration_017()
+        mock_conn, _ = _make_conn_with_agencies([])
+
+        result = mod.migrate(mock_conn, dry_run=True)
+        assert isinstance(result, dict)
+        assert result["entities_to_insert"] == 0
+        mock_conn.commit.assert_not_called()
+
+    @patch("psycopg2.extras.execute_batch")
+    def test_migrate_returns_dict_with_inserted_counts(self, mock_execute_batch):
+        mod = _import_migration_017()
+        mock_conn, _ = _make_conn_with_agencies(self.AGENCIES)
+
+        result = mod.migrate(mock_conn, dry_run=False)
+        assert isinstance(result, dict)
+        assert result["entities_inserted"] == 2
+        assert result["aliases_inserted"] >= 2
+        # Two execute_batch calls: one for entity_registry, one for entity_alias.
+        assert mock_execute_batch.call_count == 2
+
+    def test_rollback_returns_dict(self):
+        mod = _import_migration_017()
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        # rowcounts for the two DELETEs
+        type(mock_cursor).rowcount = 3
+
+        result = mod.rollback(mock_conn, dry_run=False)
+        assert isinstance(result, dict)
+        assert "entities_deleted" in result
+        assert "aliases_deleted" in result
+
+    def test_rollback_dry_run_does_not_commit(self):
+        mod = _import_migration_017()
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.side_effect = [(2,), (5,)]
+
+        result = mod.rollback(mock_conn, dry_run=True)
+        assert isinstance(result, dict)
+        assert result.get("preview") is True
+        mock_conn.commit.assert_not_called()

--- a/tests/unit/typesense/test_collection.py
+++ b/tests/unit/typesense/test_collection.py
@@ -49,11 +49,61 @@ class TestCollectionSchema:
     def test_schema_has_entity_fields(self):
         """Schema includes combined + per-type entity fields as facetable string[]."""
         fields = {f["name"]: f for f in COLLECTION_SCHEMA["fields"]}
-        for name in ("entities", "entity_org", "entity_per", "entity_loc", "entity_misc"):
+        for name in (
+            "entities",
+            "entity_org",
+            "entity_per",
+            "entity_loc",
+            "entity_misc",
+            "entity_event",
+            "entity_policy",
+            "entity_canonical",
+        ):
             assert name in fields, f"missing entity field {name}"
             assert fields[name]["type"] == "string[]"
             assert fields[name]["facet"] is True
             assert fields[name]["optional"] is True
+
+    def test_schema_declares_entity_misc(self):
+        """entity_misc must be declared (indexer routes to it; was previously missing)."""
+        field_names = [f["name"] for f in COLLECTION_SCHEMA["fields"]]
+        assert "entity_misc" in field_names
+
+    def test_schema_has_entity_canonical(self):
+        """entity_canonical (deduped canonical_id list) is a facetable optional string[]."""
+        fields = {f["name"]: f for f in COLLECTION_SCHEMA["fields"]}
+        assert "entity_canonical" in fields
+        ec = fields["entity_canonical"]
+        assert ec["type"] == "string[]"
+        assert ec["facet"] is True
+        assert ec["optional"] is True
+
+    def test_update_schema_patches_new_entity_fields_onto_existing(self):
+        """update_schema() additively PATCHes the new entity fields onto a live collection."""
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        # Live collection has the old entity set but lacks the 3 new fields.
+        mock_collection.retrieve.return_value = {
+            "fields": [
+                {"name": "unique_id", "type": "string", "facet": True},
+                {"name": "entities", "type": "string[]", "facet": True},
+                {"name": "entity_org", "type": "string[]", "facet": True},
+                {"name": "entity_per", "type": "string[]", "facet": True},
+                {"name": "entity_loc", "type": "string[]", "facet": True},
+                {"name": "entity_misc", "type": "string[]", "facet": True},
+            ]
+        }
+        mock_collection.update.return_value = {}
+        mock_client.collections.__getitem__.return_value = mock_collection
+
+        result = update_schema(mock_client)
+
+        assert "entity_event" in result["added"]
+        assert "entity_policy" in result["added"]
+        assert "entity_canonical" in result["added"]
+        # Pre-existing fields are not re-added.
+        assert "entity_misc" in result["already_exists"]
+        assert "entity_org" in result["already_exists"]
 
     def test_schema_has_view_count_sortable(self):
         """view_count is an optional, sortable int32."""

--- a/tests/unit/typesense/test_indexer.py
+++ b/tests/unit/typesense/test_indexer.py
@@ -161,16 +161,66 @@ class TestExtractEntityFields:
         result = extract_entity_fields(entities)
         assert result["entities"] == ["Ministério da Saúde", "Lula", "Brasília"]
 
-    def test_misc_event_program_go_to_entity_misc(self):
-        """MISC, EVENT and PROGRAM all fall into entity_misc."""
+    def test_event_routes_to_entity_event(self):
+        """EVENT entities go to the dedicated entity_event field."""
+        entities = [{"text": "Copa do Mundo", "type": "EVENT"}]
+        result = extract_entity_fields(entities)
+        assert result["entity_event"] == ["Copa do Mundo"]
+        assert "entity_misc" not in result
+
+    def test_policy_routes_to_entity_policy(self):
+        """POLICY entities go to the dedicated entity_policy field."""
+        entities = [{"text": "Bolsa Família", "type": "POLICY"}]
+        result = extract_entity_fields(entities)
+        assert result["entity_policy"] == ["Bolsa Família"]
+        assert "entity_misc" not in result
+
+    def test_law_work_product_go_to_entity_misc(self):
+        """LAW/WORK/PRODUCT (and unsanctioned types) bucket into entity_misc."""
         entities = [
-            {"text": "Bolsa Família", "type": "PROGRAM"},
-            {"text": "Copa do Mundo", "type": "EVENT"},
+            {"text": "Lei Maria da Penha", "type": "LAW"},
+            {"text": "Obra X", "type": "WORK"},
+            {"text": "Produto Y", "type": "PRODUCT"},
             {"text": "Algo", "type": "MISC"},
         ]
         result = extract_entity_fields(entities)
-        assert result["entity_misc"] == ["Bolsa Família", "Copa do Mundo", "Algo"]
+        assert result["entity_misc"] == [
+            "Lei Maria da Penha",
+            "Obra X",
+            "Produto Y",
+            "Algo",
+        ]
         assert "entity_org" not in result
+
+    def test_entity_canonical_collects_sorted_unique_ids(self):
+        """entity_canonical = sorted unique non-null canonical_id values."""
+        entities = [
+            {"text": "Lula", "type": "PER", "canonical_id": "Q8765"},
+            {"text": "MEC", "type": "ORG", "canonical_id": "dgb_mec"},
+            {"text": "Ministério da Educação", "type": "ORG", "canonical_id": "dgb_mec"},
+            {"text": "Anvisa", "type": "ORG"},  # no canonical_id
+            {"text": "Saúde", "type": "ORG", "canonical_id": None},  # null
+        ]
+        result = extract_entity_fields(entities)
+        assert result["entity_canonical"] == ["Q8765", "dgb_mec"]
+
+    def test_entity_canonical_absent_when_no_canonical_ids(self):
+        """entity_canonical is omitted when no mention carries a canonical_id."""
+        entities = [
+            {"text": "Anvisa", "type": "ORG"},
+            {"text": "Lula", "type": "PER", "canonical_id": None},
+        ]
+        result = extract_entity_fields(entities)
+        assert "entity_canonical" not in result
+
+    def test_entity_canonical_ignores_non_string_ids(self):
+        """Non-string canonical_id values are ignored."""
+        entities = [
+            {"text": "Anvisa", "type": "ORG", "canonical_id": 123},
+            {"text": "Lula", "type": "PER", "canonical_id": "Q8765"},
+        ]
+        result = extract_entity_fields(entities)
+        assert result["entity_canonical"] == ["Q8765"]
 
     def test_dedup_preserves_order(self):
         """Duplicate texts are removed, first-seen order preserved."""

--- a/tests/unit/workers/feature_worker/test_features.py
+++ b/tests/unit/workers/feature_worker/test_features.py
@@ -1,5 +1,6 @@
 """Unit tests for feature computation functions."""
 
+import unicodedata
 from datetime import datetime, timezone
 
 import pytest
@@ -217,6 +218,42 @@ class TestComputeContentAnnotations:
         assert content[second["start"] : second["end"]] == "educação"
         assert first["type"] == "POLICY"
         assert first["canonical_id"] is None
+
+    def test_nfd_content_offsets_index_original_string(self):
+        """REGRESSION: NFD (decomposed) content must yield offsets that slice the
+        ORIGINAL string correctly. NFC normalization is NOT length-preserving, so
+        the previous equal-length assumption corrupted offsets after the first
+        decomposed accent (INSS sliced to ' INS')."""
+        content = unicodedata.normalize("NFD", "No Ministério da Saúde, o INSS agiu.")
+        # Sanity: the fixture really is decomposed (not already NFC).
+        assert content != unicodedata.normalize("NFC", content)
+        entities = [{"text": "INSS", "type": "ORG", "canonical_id": "dgb_inss"}]
+        result = compute_content_annotations(content, entities)
+        assert len(result) == 1
+        assert content[result[0]["start"] : result[0]["end"]] == "INSS"
+        assert result[0]["text"] == "INSS"
+
+    def test_nfd_accented_entity_in_nfd_content(self):
+        """Accented surface matched in NFD content returns the correct original
+        (decomposed) slice — offsets index the original, not a renormalized copy."""
+        content = unicodedata.normalize("NFD", "O Ministério da Saúde divulgou dados.")
+        assert content != unicodedata.normalize("NFC", content)
+        entities = [{"text": "Saúde", "type": "ORG", "canonical_id": "dgb_ms"}]
+        result = compute_content_annotations(content, entities)
+        assert len(result) == 1
+        start, end = result[0]["start"], result[0]["end"]
+        # The slice equals 'Saúde' under NFC comparison (it is the NFD form here).
+        assert unicodedata.normalize("NFC", content[start:end]) == "Saúde"
+        assert result[0]["text"] == content[start:end]
+
+    def test_fold_expansion_maps_back_to_original_span(self):
+        """A surface whose fold EXPANDS the source (ß → ss) still maps its span
+        back to the original (shorter) codepoints — index map handles contraction."""
+        content = "Die Straße ist hier."
+        entities = [{"text": "Strasse", "type": "LOC", "canonical_id": None}]
+        result = compute_content_annotations(content, entities)
+        assert len(result) == 1
+        assert content[result[0]["start"] : result[0]["end"]] == "Straße"
 
     def test_word_boundary_prevents_substring_match(self):
         """'MEC' must not match inside 'MECANICA' or 'COMEÇO'."""

--- a/tests/unit/workers/feature_worker/test_features.py
+++ b/tests/unit/workers/feature_worker/test_features.py
@@ -7,6 +7,7 @@ import pytest
 from data_platform.workers.feature_worker.features import (
     compute_all,
     compute_char_count,
+    compute_content_annotations,
     compute_has_image,
     compute_has_video,
     compute_paragraph_count,
@@ -150,3 +151,147 @@ class TestComputeAll:
 
         assert "publication_hour" not in features
         assert "publication_dow" not in features
+
+
+class TestComputeContentAnnotations:
+    """Tests for compute_content_annotations() — deterministic offset derivation."""
+
+    def test_simple_single_occurrence(self):
+        content = "O MEC anunciou novidades."
+        entities = [{"text": "MEC", "type": "ORG", "canonical_id": "dgb_mec"}]
+        result = compute_content_annotations(content, entities)
+        assert result == [
+            {"start": 2, "end": 5, "type": "ORG", "text": "MEC", "canonical_id": "dgb_mec"}
+        ]
+        # Verify the slice matches the original surface exactly.
+        assert content[2:5] == "MEC"
+
+    def test_nested_overlap_longest_match_wins(self):
+        """'Ministério da Educação (MEC)' engulfs the nested 'MEC'; a later
+        standalone 'MEC' still matches."""
+        content = "O Ministério da Educação (MEC) agiu. Depois o MEC voltou."
+        entities = [
+            {"text": "Ministério da Educação (MEC)", "type": "ORG", "canonical_id": "dgb_mec"},
+            {"text": "MEC", "type": "ORG", "canonical_id": "dgb_mec"},
+        ]
+        result = compute_content_annotations(content, entities)
+        # First span = the long surface; the nested MEC inside it is dropped.
+        long_start = content.index("Ministério da Educação (MEC)")
+        long_end = long_start + len("Ministério da Educação (MEC)")
+        standalone_start = content.index("MEC", long_end)
+        assert result == [
+            {
+                "start": long_start,
+                "end": long_end,
+                "type": "ORG",
+                "text": "Ministério da Educação (MEC)",
+                "canonical_id": "dgb_mec",
+            },
+            {
+                "start": standalone_start,
+                "end": standalone_start + 3,
+                "type": "ORG",
+                "text": "MEC",
+                "canonical_id": "dgb_mec",
+            },
+        ]
+
+    def test_multiple_occurrences_all_marked(self):
+        content = "Lula falou. Lula repetiu. Lula concluiu."
+        entities = [{"text": "Lula", "type": "PER", "canonical_id": "Q8765"}]
+        result = compute_content_annotations(content, entities)
+        starts = [a["start"] for a in result]
+        assert starts == [0, 12, 26]
+        for a in result:
+            assert content[a["start"] : a["end"]] == "Lula"
+
+    def test_accent_and_case_insensitive_preserves_offsets(self):
+        """Match is accent/case-insensitive but offsets/text reflect the original."""
+        content = "A EDUCACAO e a educação importam."
+        entities = [{"text": "Educação", "type": "POLICY", "canonical_id": None}]
+        result = compute_content_annotations(content, entities)
+        # Both 'EDUCACAO' (no accent, uppercase) and 'educação' (lowercase, accent) match.
+        assert len(result) == 2
+        first, second = result
+        assert content[first["start"] : first["end"]] == "EDUCACAO"
+        assert content[second["start"] : second["end"]] == "educação"
+        assert first["type"] == "POLICY"
+        assert first["canonical_id"] is None
+
+    def test_word_boundary_prevents_substring_match(self):
+        """'MEC' must not match inside 'MECANICA' or 'COMEÇO'."""
+        content = "A MECANICA do COMEÇO. Mas o MEC sim."
+        entities = [{"text": "MEC", "type": "ORG", "canonical_id": None}]
+        result = compute_content_annotations(content, entities)
+        assert len(result) == 1
+        assert content[result[0]["start"] : result[0]["end"]] == "MEC"
+
+    def test_internal_whitespace_collapsed(self):
+        """Multiple spaces / newlines in content between surface words still match."""
+        content = "O Ministério   da\nEducação cresceu."
+        entities = [{"text": "Ministério da Educação", "type": "ORG", "canonical_id": "dgb_mec"}]
+        result = compute_content_annotations(content, entities)
+        assert len(result) == 1
+        # `text` reflects the ORIGINAL slice (with the real whitespace run).
+        assert result[0]["text"] == "Ministério   da\nEducação"
+        assert content[result[0]["start"] : result[0]["end"]] == "Ministério   da\nEducação"
+
+    def test_surface_not_in_content_skipped_silently(self):
+        content = "Texto sobre saúde pública."
+        entities = [
+            {"text": "Bolsa Família", "type": "POLICY", "canonical_id": "dgb_bf"},
+            {"text": "saúde", "type": "POLICY", "canonical_id": None},
+        ]
+        result = compute_content_annotations(content, entities)
+        # Only 'saúde' is present.
+        assert len(result) == 1
+        assert result[0]["text"] == "saúde"
+
+    def test_output_is_flat_sorted_non_overlapping(self):
+        content = "Brasília recebeu Lula e o MEC na quarta."
+        entities = [
+            {"text": "MEC", "type": "ORG", "canonical_id": "dgb_mec"},
+            {"text": "Lula", "type": "PER", "canonical_id": "Q8765"},
+            {"text": "Brasília", "type": "LOC", "canonical_id": "Q2844"},
+        ]
+        result = compute_content_annotations(content, entities)
+        starts = [a["start"] for a in result]
+        assert starts == sorted(starts)
+        # No overlap.
+        for prev, nxt in zip(result, result[1:], strict=False):
+            assert prev["end"] <= nxt["start"]
+
+    def test_idempotent_same_input_same_output(self):
+        content = "O Ministério da Educação (MEC) e o MEC."
+        entities = [
+            {"text": "Ministério da Educação (MEC)", "type": "ORG", "canonical_id": "dgb_mec"},
+            {"text": "MEC", "type": "ORG", "canonical_id": "dgb_mec"},
+        ]
+        first = compute_content_annotations(content, entities)
+        second = compute_content_annotations(content, entities)
+        assert first == second
+
+    def test_empty_entities_returns_empty(self):
+        assert compute_content_annotations("Algum texto.", []) == []
+
+    def test_empty_content_returns_empty(self):
+        entities = [{"text": "MEC", "type": "ORG", "canonical_id": None}]
+        assert compute_content_annotations("", entities) == []
+        assert compute_content_annotations(None, entities) == []
+
+    def test_tie_break_equal_span_by_count_then_order(self):
+        """When two entities match the exact same span, higher count wins."""
+        content = "O MEC agiu."
+        entities = [
+            {"text": "MEC", "type": "ORG", "canonical_id": "dgb_a", "count": 1},
+            {"text": "MEC", "type": "ORG", "canonical_id": "dgb_b", "count": 9},
+        ]
+        result = compute_content_annotations(content, entities)
+        assert len(result) == 1
+        assert result[0]["canonical_id"] == "dgb_b"
+
+    def test_missing_canonical_id_defaults_null(self):
+        content = "O MEC agiu."
+        entities = [{"text": "MEC", "type": "ORG"}]
+        result = compute_content_annotations(content, entities)
+        assert result[0]["canonical_id"] is None

--- a/tests/unit/workers/feature_worker/test_handler.py
+++ b/tests/unit/workers/feature_worker/test_handler.py
@@ -39,6 +39,7 @@ class TestHandleFeatureComputation:
                 "https://example.com/img.jpg",
                 None,
                 datetime(2024, 6, 17, 14, 0, 0, tzinfo=timezone.utc),
+                None,  # entities
             )
         )
         conn.cursor.return_value = cursor
@@ -51,6 +52,8 @@ class TestHandleFeatureComputation:
         assert isinstance(result["features"], list)
         assert "word_count" in result["features"]
         assert "has_image" in result["features"]
+        assert "content_annotations" in result["features"]
+        assert "annotations_source_hash" in result["features"]
 
     def test_returns_not_found_for_missing_article(self, mock_pg):
         conn = MagicMock()
@@ -73,6 +76,7 @@ class TestHandleFeatureComputation:
                 None,
                 None,
                 datetime(2024, 6, 17, 9, 0, 0),
+                None,
             )
         )
         conn.cursor.return_value = cursor
@@ -93,7 +97,7 @@ class TestHandleFeatureComputation:
     def test_propagates_upsert_error(self, mock_pg):
         conn = MagicMock()
         cursor = _make_cursor(
-            row=("abc123", "Conteúdo.", None, None, datetime(2024, 1, 1))
+            row=("abc123", "Conteúdo.", None, None, datetime(2024, 1, 1), None)
         )
         conn.cursor.return_value = cursor
         mock_pg.get_connection.return_value = conn
@@ -105,7 +109,7 @@ class TestHandleFeatureComputation:
     def test_connection_returned_to_pool_on_success(self, mock_pg):
         conn = MagicMock()
         cursor = _make_cursor(
-            row=("abc123", "Conteúdo.", None, None, datetime(2024, 1, 1))
+            row=("abc123", "Conteúdo.", None, None, datetime(2024, 1, 1), None)
         )
         conn.cursor.return_value = cursor
         mock_pg.get_connection.return_value = conn
@@ -133,6 +137,7 @@ class TestHandleFeatureComputation:
                 None,
                 None,
                 datetime(2024, 6, 17, 14, 30, 0, tzinfo=timezone.utc),
+                None,
             )
         )
         conn.cursor.return_value = cursor
@@ -148,7 +153,7 @@ class TestHandleFeatureComputation:
     def test_features_omit_publication_fields_when_published_at_none(self, mock_pg):
         conn = MagicMock()
         cursor = _make_cursor(
-            row=("abc123", "Texto de artigo.", None, None, None)
+            row=("abc123", "Texto de artigo.", None, None, None, None)
         )
         conn.cursor.return_value = cursor
         mock_pg.get_connection.return_value = conn
@@ -158,3 +163,97 @@ class TestHandleFeatureComputation:
         features_arg = mock_pg.upsert_features.call_args[0][1]
         assert "publication_hour" not in features_arg
         assert "publication_dow" not in features_arg
+
+    def test_content_annotations_derived_from_entities(self, mock_pg):
+        """Existing entities in news_features yield inline offsets in the upsert."""
+        conn = MagicMock()
+        cursor = _make_cursor(
+            row=(
+                "abc123",
+                "O MEC anunciou novidades hoje cedo de manhã.",
+                None,
+                None,
+                datetime(2024, 1, 1),
+                [{"text": "MEC", "type": "ORG", "canonical_id": "dgb_mec"}],
+            )
+        )
+        conn.cursor.return_value = cursor
+        mock_pg.get_connection.return_value = conn
+
+        handle_feature_computation("abc123", mock_pg)
+
+        features_arg = mock_pg.upsert_features.call_args[0][1]
+        anns = features_arg["content_annotations"]
+        assert anns == [
+            {"start": 2, "end": 5, "type": "ORG", "text": "MEC", "canonical_id": "dgb_mec"}
+        ]
+        assert isinstance(features_arg["annotations_source_hash"], str)
+
+    def test_content_annotations_empty_when_entities_absent(self, mock_pg):
+        """No entities (race with enrichment worker) → empty annotations, no crash."""
+        conn = MagicMock()
+        cursor = _make_cursor(
+            row=("abc123", "Texto sem entidades.", None, None, datetime(2024, 1, 1), None)
+        )
+        conn.cursor.return_value = cursor
+        mock_pg.get_connection.return_value = conn
+
+        result = handle_feature_computation("abc123", mock_pg)
+
+        assert result["status"] == "computed"
+        features_arg = mock_pg.upsert_features.call_args[0][1]
+        assert features_arg["content_annotations"] == []
+
+    def test_content_annotations_from_json_string_entities(self, mock_pg):
+        """Entities arriving as a JSON-encoded string (driver variance) still parse."""
+        import json
+
+        conn = MagicMock()
+        cursor = _make_cursor(
+            row=(
+                "abc123",
+                "Lula discursou em Brasília.",
+                None,
+                None,
+                datetime(2024, 1, 1),
+                json.dumps([{"text": "Lula", "type": "PER", "canonical_id": "Q8765"}]),
+            )
+        )
+        conn.cursor.return_value = cursor
+        mock_pg.get_connection.return_value = conn
+
+        handle_feature_computation("abc123", mock_pg)
+
+        features_arg = mock_pg.upsert_features.call_args[0][1]
+        anns = features_arg["content_annotations"]
+        assert len(anns) == 1
+        assert anns[0]["text"] == "Lula"
+        assert anns[0]["canonical_id"] == "Q8765"
+
+    def test_upsert_merges_without_dropping_other_keys(self, mock_pg):
+        """The handler passes a feature dict; upsert_features merges via JSONB || so
+        other pre-existing keys (e.g. entities, sentiment) are preserved upstream.
+        Here we assert the handler does not overwrite the whole features object —
+        it only adds the keys it computed (incl. content_annotations)."""
+        conn = MagicMock()
+        cursor = _make_cursor(
+            row=(
+                "abc123",
+                "O MEC agiu.",
+                None,
+                None,
+                datetime(2024, 1, 1),
+                [{"text": "MEC", "type": "ORG", "canonical_id": "dgb_mec"}],
+            )
+        )
+        conn.cursor.return_value = cursor
+        mock_pg.get_connection.return_value = conn
+
+        handle_feature_computation("abc123", mock_pg)
+
+        features_arg = mock_pg.upsert_features.call_args[0][1]
+        # The handler must NOT include `entities` in its upsert payload (it only
+        # reads them), so the existing entities are never clobbered by the merge.
+        assert "entities" not in features_arg
+        assert "content_annotations" in features_arg
+        assert "word_count" in features_arg

--- a/tests/unit/workers/feature_worker/test_handler.py
+++ b/tests/unit/workers/feature_worker/test_handler.py
@@ -22,8 +22,19 @@ def mock_pg():
     return pg
 
 
+# The PG fetch query returns 8 columns:
+#   unique_id, content, image_url, video_url, published_at,
+#   entities, annotations_source_hash, has_content_annotations
+_ROW_WIDTH = 8
+
+
 def _make_cursor(row=None):
     cursor = MagicMock()
+    # Pad shorter test rows with None for the trailing annotation-skip columns
+    # (annotations_source_hash, has_content_annotations) so callers can keep
+    # passing the core fields only.
+    if row is not None and len(row) < _ROW_WIDTH:
+        row = (*row, *([None] * (_ROW_WIDTH - len(row))))
     cursor.fetchone.return_value = row
     cursor.close = MagicMock()
     return cursor
@@ -257,3 +268,100 @@ class TestHandleFeatureComputation:
         assert "entities" not in features_arg
         assert "content_annotations" in features_arg
         assert "word_count" in features_arg
+
+    def test_annotations_recompute_skipped_when_hash_unchanged(self, mock_pg):
+        """When stored hash matches AND content_annotations exists, the annotation
+        derivation is skipped (not re-written), but other features still upsert."""
+        from data_platform.workers.feature_worker.features import (
+            compute_annotations_source_hash,
+        )
+
+        content = "O MEC agiu."
+        entities = [{"text": "MEC", "type": "ORG", "canonical_id": "dgb_mec"}]
+        stored_hash = compute_annotations_source_hash(content, entities)
+
+        conn = MagicMock()
+        cursor = _make_cursor(
+            row=(
+                "abc123",
+                content,
+                None,
+                None,
+                datetime(2024, 1, 1),
+                entities,
+                stored_hash,  # annotations_source_hash matches
+                True,  # has_content_annotations
+            )
+        )
+        conn.cursor.return_value = cursor
+        mock_pg.get_connection.return_value = conn
+
+        result = handle_feature_computation("abc123", mock_pg)
+
+        assert result["annotations_skipped"] is True
+        features_arg = mock_pg.upsert_features.call_args[0][1]
+        # Skipped → neither annotation key is in the upsert payload …
+        assert "content_annotations" not in features_arg
+        assert "annotations_source_hash" not in features_arg
+        # … but the cheap content-driven features are still recomputed.
+        assert "word_count" in features_arg
+
+    def test_annotations_recompute_runs_when_hash_changes(self, mock_pg):
+        """A stale stored hash (entities changed) forces recompute of annotations."""
+        conn = MagicMock()
+        cursor = _make_cursor(
+            row=(
+                "abc123",
+                "O MEC agiu.",
+                None,
+                None,
+                datetime(2024, 1, 1),
+                [{"text": "MEC", "type": "ORG", "canonical_id": "dgb_mec"}],
+                "stale-hash-does-not-match",
+                True,
+            )
+        )
+        conn.cursor.return_value = cursor
+        mock_pg.get_connection.return_value = conn
+
+        result = handle_feature_computation("abc123", mock_pg)
+
+        assert result["annotations_skipped"] is False
+        features_arg = mock_pg.upsert_features.call_args[0][1]
+        assert features_arg["content_annotations"] == [
+            {"start": 2, "end": 5, "type": "ORG", "text": "MEC", "canonical_id": "dgb_mec"}
+        ]
+        assert "annotations_source_hash" in features_arg
+
+    def test_annotations_recompute_runs_when_key_absent_even_if_hash_matches(self, mock_pg):
+        """Hash matches but content_annotations key is missing → must recompute
+        (guards against a hash written without the annotations list)."""
+        from data_platform.workers.feature_worker.features import (
+            compute_annotations_source_hash,
+        )
+
+        content = "O MEC agiu."
+        entities = [{"text": "MEC", "type": "ORG", "canonical_id": "dgb_mec"}]
+        stored_hash = compute_annotations_source_hash(content, entities)
+
+        conn = MagicMock()
+        cursor = _make_cursor(
+            row=(
+                "abc123",
+                content,
+                None,
+                None,
+                datetime(2024, 1, 1),
+                entities,
+                stored_hash,
+                False,  # content_annotations key NOT present
+            )
+        )
+        conn.cursor.return_value = cursor
+        mock_pg.get_connection.return_value = conn
+
+        result = handle_feature_computation("abc123", mock_pg)
+
+        assert result["annotations_skipped"] is False
+        features_arg = mock_pg.upsert_features.call_args[0][1]
+        assert "content_annotations" in features_arg


### PR DESCRIPTION
Parte da evolução do identificador de entidades (#178). Plano em `_plan/EVOLUCAO-IDENTIFICADOR-ENTIDADES-NER.md`.

## O que entra
- **Migrações 015–020**: `entity_registry` (canônico, Neo4j-ready), `entity_alias` (resolver determinístico), seed de 159 órgãos a partir de `agencies`, índice GIN canonical, `news_llm_raw` (reprocessável sem re-chamar Bedrock), `entity_registry_seen` (estado da canonicalização).
- **Typesense**: campos `entity_event`/`entity_policy`/`entity_canonical` + correção do bug `entity_misc` (tipos fora de ORG/PER/LOC eram perdidos); indexer roteia EVENT/POLICY e emite `canonical_id`.
- **Lente semântica**: feature-worker `compute_content_annotations` (offsets determinísticos, mapa folded→original robusto a NFD/casefold).

## Testes
586 unit tests verdes. Revisão adversarial aplicada (colisão de alias e bug crítico de offsets NFD corrigidos).

## Gates de deploy
Migrações via `db-migrate.yaml`; schema via `typesense-schema-update.yaml` + `typesense-maintenance-sync.yaml`. Reprocessamento de ~1 mês após deploy → validar → backfill gradual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)