### PR TITLE
feat: DAGs de backfill NER+canon + migração 023 ledger de cota

### DIFF
--- a/_plan/BACKFILL-ENTIDADES-ORQUESTRACAO.md
+++ b/_plan/BACKFILL-ENTIDADES-ORQUESTRACAO.md
@@ -1,0 +1,108 @@
+# Backfill & orquestração da identificação de entidades (NER + canonicalização → grafo) com governador de cota
+
+> **STATUS: 🟡 EM IMPLEMENTAÇÃO (2026-06-17)**
+> Continuação operacional de `EVOLUCAO-IDENTIFICADOR-ENTIDADES-NER.md` (Fases 1–5) e `FASE6-PROJECAO-GRAFO-ENTIDADES-NEO4J.md` (Fase 6). Aquelas entregaram o **código**; este plano entrega a **execução do backfill** sobre o acervo, sob teto de cota.
+
+## Context
+
+As Fases 1–6 estão **implementadas e em produção**, mas o backfill **estagnou em 11/jun**. Medição em prod (2026-06-17, psql read-only):
+
+| Métrica (prod) | Valor |
+|---|---|
+| `news` total | 335.268 |
+| com features | 26.925 (8,0%) |
+| com entidades (NER) | 21.463 (6,4%) — maioria ainda **Haiku 3 legado** |
+| re-NERados `ner-v1` (Sonnet 4.6) | 4.732 (1,4%) — janela 2026-05-12→06-17 (fatia de validação) |
+| com `canonical_id` | 3.909 (1,2%) — quase todos via **gazetteer**, não LLM |
+| `entity_registry_seen` | **20.724 pending** / 118 resolved / 65 needs_review |
+| → das pendentes com `attempts=0` | **20.718** (nunca tentadas) |
+| `entity_registry_seen.updated_at` máx | **2026-06-11 13:31** (job não roda há 6 dias) |
+| grafo | 242 nós, 788 arestas, 6.471 menções, 3.909 artigos |
+
+**Causa raiz: orquestração, não quota.** O Step B da canonicalização praticamente nunca rodou (20.718 formas com `attempts=0`). Os CLIs existem (`canonicalization_job.py`, `renew_ner_window.py`) mas são **manuais, sem empacotamento nem agendamento**.
+
+**Modelos — confirmado empiricamente (boto3, conta 048894428441, us-east-1, 2026-06-17):**
+- `us.anthropic.claude-sonnet-4-6` → ✅ invoca, retorna `usage{input_tokens,output_tokens}`
+- `us.anthropic.claude-opus-4-6-v1` → ✅ invoca (config atual do canon)
+- `us.anthropic.claude-opus-4-8` → ❌ **AccessDeniedException (não habilitado)**
+
+**Decisão:** usar **Sonnet 4.6 para NER e canonicalização**. Evita dependência de Opus, simplifica o governador (um único pool de cota Sonnet, compartilhado por worker-ao-vivo + NER-backfill + canon-backfill) e é configurável por env (Opus 4.6 permanece disponível como upgrade futuro de qualidade do canon, sem mudar código). Model vars já em prod: `NER_MODEL_ID=us.anthropic.claude-sonnet-4-6`; `CANON_MODEL_ID` passa de Opus 4.6 → **Sonnet 4.6**.
+
+**Objetivo:** produtizar e agendar os jobs de backfill sob um **governador de cota** que limita este processo a **80% da cota diária de tokens do Bedrock**, deixando ≥20% para os outros consumidores LLM. Decisões do usuário: **Cloud Run Job + DAG do Composer**; escopo **completo (incl. ~314k NER histórico)**; **grind resumível**; **teto 80%**.
+
+## Arquitetura
+
+CLIs de batch → **Cloud Run Jobs** (execuções longas, resumíveis, sem ack-deadline). Lógica Bedrock no **data-science**; **data-platform** agenda via **DAGs do Composer** com `CloudRunExecuteJobOperator` (provider google ≥10.14). Grafo (`project_entity_graph` + `sync_graph_to_neo4j`, 6h) **cresce sozinho** conforme `canonical_id` aumenta.
+
+```
+infra (Terraform)                 data-science (imagens + lógica)         data-platform (Composer + schema)
+cloud_run_v2_job canon-backfill ◄ docker/canon-job + canonicalization_job  dag canonicalize_backfill ─┐
+cloud_run_v2_job ner-backfill   ◄ docker/ner-job + backfill_ner_corpus     dag ner_backfill           ├ CloudRunExecuteJobOperator
+  + SAs + secret IAM            ◄ quota_governor.py (lê ledger, decide)     migration 023 llm_daily_usage
+  + IAM Composer→run.developer    + captura usage de TODA chamada Bedrock   (ledger de tokens)
+  + quota env (JSON por modelo)   (jobs + worker ao vivo) → ledger
+```
+
+**Contrato fixo (para os subagentes não negociarem):**
+- Tabela ledger: `llm_daily_usage(day DATE, model_id TEXT, input_tokens BIGINT, output_tokens BIGINT, PRIMARY KEY(day, model_id))`.
+- Jobs: `destaquesgovbr-canon-backfill`, `destaquesgovbr-ner-backfill`; region `southamerica-east1`.
+- Env dos jobs: `DATABASE_URL`, `AWS_BEDROCK_CONNECTION_URI` (Secret Manager), `NER_MODEL_ID`/`CANON_MODEL_ID`, `BEDROCK_DAILY_TOKEN_QUOTA` (JSON `{model_id: tokens/dia}`), `BACKFILL_QUOTA_FRACTION="0.8"`.
+- Modelo (ambos): `us.anthropic.claude-sonnet-4-6`. `anthropic_version="bedrock-2023-05-31"`.
+
+## Governador de cota (≤80% da cota diária) — peça central
+
+O backfill **se auto-limita**; o worker ao vivo nunca para. Cede quando o consumo **do dia, account-wide, para o modelo** atinge `0.8 × cota_diária`.
+
+- **Captura de tokens:** hoje `raw_meta` (llm_client.py:577) **descarta** o `usage` do Bedrock. Passar a capturar `usage.input_tokens/output_tokens` em **todas** as chamadas (NER, combinada Haiku, canon).
+- **Ledger (Postgres):** `llm_daily_usage` (migração 023). **Todos os chamadores** (jobs de backfill **e** worker ao vivo) fazem `UPSERT ... += tokens`. Como os consumidores de texto são os mesmos (worker combinado Haiku, Sonnet NER, Sonnet canon), o ledger reflete o consumo real por modelo.
+- **Decisão (só nos jobs):** antes de cada chamada/batch, `usado = SUM(input+output) WHERE day=current_date AND model_id=<modelo>`; se `usado ≥ 0.8 × cota(modelo)` → **parar gracioso** (exit 0; resumível amanhã). Como NER e canon usam Sonnet 4.6, ambos medem contra o **mesmo pool**; os 20% sobram para o worker ao vivo.
+- **Config:** cotas reais por modelo via env (`BEDROCK_DAILY_TOKEN_QUOTA`, lidas do AWS Service Quotas — **nunca inventadas**), setadas no Terraform; `BACKFILL_QUOTA_FRACTION=0.8` configurável.
+- **Rede de segurança:** manter tratamento de `ThrottlingException` (back-off + parada limpa). UPSERT atômico (`ON CONFLICT DO UPDATE SET tokens = tokens + EXCLUDED.tokens`); checagem a cada N chamadas tolera pequena ultrapassagem (margem ~78–80%).
+
+## Work breakdown (por repo)
+
+### A. data-science
+- **`src/news_enrichment/quota_governor.py`** (novo): `record_usage(conn, model_id, in_tok, out_tok)` (UPSERT), `tokens_used_today(conn, model_id)`, `budget_exhausted(conn, model_id, quota, fraction)`. Puro/testável.
+- **Captura `usage`** em `llm_client.py` (NER + combinada) e na chamada canon (`canonicalization.llm_canonicalize`/`apply_gates`) → devolve no `raw_meta` e chama `record_usage`.
+- **Wire do governador** em `canonicalization_job.resolve_pending` e no driver NER (check `budget_exhausted` antes de cada forma/artigo, ou a cada N).
+- **`scripts/backfill_ner_corpus.py`** (novo, ou `--from-scratch` em `renew_ner_window.py`): seleciona `news` SEM `news_llm_raw` task='ner' prompt_version='ner-v1' (cobre os ~314k sem NER), resumível, capado, ordem configurável; `_upsert_ai_features` com **INSERT-on-conflict** quando não há linha `news_features`.
+- **`docker/canonicalization-job/Dockerfile`** + **`docker/ner-backfill-job/Dockerfile`**: base = enrichment-worker; `ENTRYPOINT` = shim que parseia `AWS_BEDROCK_CONNECTION_URI` → `AWS_ACCESS_KEY_ID/SECRET/REGION` discretos e `exec`uta o CLI com `"$@"`.
+- **Worker ao vivo** (`worker/handler.py`): chamar `record_usage` (só escreve; não se auto-limita).
+- **Config canon**: `get_canon_model_id()` continua lendo `CANON_MODEL_ID`; default de prod (Terraform) → Sonnet 4.6.
+- **Fixes**: `mint_internal_id` (canonicalization.py:107) trunca slug ~52 chars + sufixo hash (evita estouro de `varchar(64)`); `poetry add httpx` (importado em wikidata_client.py:20, ausente do pyproject).
+- **Testes** (Bedrock/Wikidata mockados): governador, captura de usage, driver histórico, mint bound, shim de creds.
+- **CI**: 2 workflows `*-job-deploy.yaml` reusando `cloud-run-deploy.yml@v2`.
+
+### B. infra (só escreve `.tf`; nunca apply local)
+- **`terraform/canonicalization-job.tf`** + **`terraform/ner-backfill-job.tf`**: `google_cloud_run_v2_job` (region SP); env conforme contrato; `timeout` ~3600s; SA dedicada + IAM `secretAccessor` (DB + aws_bedrock secrets).
+- **`terraform/variables.tf`** (append): `bedrock_daily_token_quota` (JSON/map) + `backfill_quota_fraction` (default `0.8`); ajustar `canon_model_id` default → `us.anthropic.claude-sonnet-4-6`.
+- **IAM Composer→Jobs** (`composer_iam.tf`): SA do Composer com `roles/run.developer`.
+- **Airflow Variables** (`composer_secrets.tf`): `canon_job_name`, `ner_job_name`, `cloud_run_jobs_region`.
+
+### C. data-platform
+- **`scripts/migrations/023_create_llm_daily_usage.sql`** (+ rollback): tabela do ledger. Aplicar via `db-migrate.yaml`.
+- **`src/data_platform/dags/canonicalize_backfill.py`** + **`ner_backfill.py`**: `@dag` diário (defasados), `max_active_runs=1`, `catchup=False`; task `CloudRunExecuteJobOperator` (job/region via `Variable.get`) com `overrides` (`--since`/`--limit` guard secundário; governador é o teto primário). Sem novo módulo em `jobs/` (lógica vive na imagem).
+
+## Orquestração com subagentes (Workflow)
+
+1. **Foundation (paralela):** `data-science` ‖ `data-platform-schema` (migração 023) ‖ `infra` (`.tf`, write-only).
+2. **Consumers:** `data-platform-dags` (2 DAGs) — usa nomes/region dos Jobs + tabela ledger do contrato.
+3. **Review (paralela, adversarial por repo):** segurança (creds via Secret Manager, SA mínima), corretude do governador (race UPSERT; soma dia/modelo; parada limpa), SQL do selector histórico (índices), idempotência/resumibilidade. Findings → fix.
+
+Pós-workflow (usuário/GitOps): testes locais; PRs; migração 023 via `db-migrate.yaml`; CI builda imagens; terraform-apply cria Jobs+IAM; composer-deploy publica DAGs; despausar e **monitorar drain** (`entity_registry_seen`, `with_canonical_id`, `llm_daily_usage`); `typesense-maintenance-sync.yaml` quando cobertura subir. Atualizar memória `[[project_dgb_entity_canonicalization]]`.
+
+## Verificação (E2E)
+1. **data-science (venv):** `pytest` (governador cap 80%, captura usage, driver histórico, mint bound); `--dry-run` do canon e NER contra DB dev; smoke do shim de creds.
+2. **data-platform:** migração 023 `--dry-run` + apply; `llm_daily_usage` criada.
+3. **infra:** revisar `terraform-plan` (2 Jobs, SAs, secret IAM, run.developer, quota vars). Após apply: `gcloud run jobs execute <canon> --args="--limit=20"` e checar ledger.
+4. **Orquestração:** trigger manual das DAGs; medir delta `entity_registry_seen` (pending↓/resolved↑), `with_canonical_id`↑, e parada ao bater 80% (logs "budget exhausted").
+5. **Grafo + portal:** `project_entity_graph` na próxima run > 242/788; Playwright serial (`e2e/graphql/entities.spec.ts`, `--workers=1`).
+
+## Riscos & gates
+- **Cota diária** = teto: governador a 80% (ledger account-wide por modelo) garante ≥20% para o worker ao vivo; jobs resumíveis ⇒ atraso não-bloqueante.
+- **Race no ledger**: UPSERT atômico; checagem periódica com margem.
+- **Cotas reais**: ler do AWS Service Quotas; nunca inventar. Sem valor → começar conservador, ajustar por env (sem redeploy de código).
+- **Credenciais no Job**: Secret Manager; SA dedicada mínima; nunca chave em texto no `.tf`.
+- **Selector histórico (314k)**: sem full-scan caro — `NOT EXISTS` sobre `news_llm_raw(unique_id,task,prompt_version)` + índice em `published_at`.
+- **Infra/Composer/Python**: subagentes só escrevem arquivos; deploy via PR+CI; nunca `terraform`/`gcloud` infra local; Python sempre em venv.
+- **Portal durante R1**: branch `development`, nunca `main`.

--- a/_plan/INDEX.md
+++ b/_plan/INDEX.md
@@ -17,10 +17,16 @@
 
 ---
 
+## 🧩 Entidades (NER → canonicalização → grafo)
+
+- [EVOLUCAO-IDENTIFICADOR-ENTIDADES-NER.md](EVOLUCAO-IDENTIFICADOR-ENTIDADES-NER.md) — Fases 1–5 (taxonomia, registry, canonicalização, lente) ✅ em produção
+- [FASE6-PROJECAO-GRAFO-ENTIDADES-NEO4J.md](FASE6-PROJECAO-GRAFO-ENTIDADES-NEO4J.md) — Fase 6 (grafo Postgres→Neo4j) ✅ em produção
+- [BACKFILL-ENTIDADES-ORQUESTRACAO.md](BACKFILL-ENTIDADES-ORQUESTRACAO.md) — 🟡 Backfill NER+canon como Cloud Run Jobs + DAGs + governador de cota 80% (Sonnet 4.6)
+
 ## 📋 Outros Documentos
 
 - [bateria-testes-integracao.md](bateria-testes-integracao.md) - Testes de integração do pipeline
 
 ---
 
-**Última atualização**: 2025-12-30
+**Última atualização**: 2026-06-17

--- a/scripts/migrations/023_create_llm_daily_usage.sql
+++ b/scripts/migrations/023_create_llm_daily_usage.sql
@@ -1,0 +1,23 @@
+-- 023_create_llm_daily_usage.sql
+-- Ledger de consumo de tokens do Bedrock (Anthropic), account-wide, agregado por dia x modelo.
+-- Todos os chamadores LLM (worker ao vivo + jobs de backfill NER/canon) fazem UPSERT += tokens
+-- a cada chamada, lendo usage.input_tokens/usage.output_tokens da resposta do Bedrock.
+-- Lastreia o governador de cota: antes de cada batch, os jobs somam o consumo do dia para o
+-- modelo e param graciosamente ao atingir 80% (BACKFILL_QUOTA_FRACTION) da cota diaria,
+-- deixando >=20% para o worker ao vivo. A PK (day, model_id) ja serve a query SUM por dia+modelo;
+-- sem indices extras. Ref: data-platform — Backfill & orquestracao de entidades (migracao 023).
+
+CREATE TABLE IF NOT EXISTS llm_daily_usage (
+    day           DATE   NOT NULL,                  -- dia (UTC) do consumo agregado
+    model_id      TEXT   NOT NULL,                  -- ex.: 'us.anthropic.claude-sonnet-4-6'
+    input_tokens  BIGINT NOT NULL DEFAULT 0,        -- soma dos input_tokens do dia para o modelo
+    output_tokens BIGINT NOT NULL DEFAULT 0,        -- soma dos output_tokens do dia para o modelo
+    PRIMARY KEY (day, model_id)
+);
+
+-- UPSERT atomico usado por todos os chamadores (acumula, nunca sobrescreve):
+--   INSERT INTO llm_daily_usage (day, model_id, input_tokens, output_tokens)
+--   VALUES (CURRENT_DATE, :model_id, :in, :out)
+--   ON CONFLICT (day, model_id) DO UPDATE SET
+--       input_tokens  = llm_daily_usage.input_tokens  + EXCLUDED.input_tokens,
+--       output_tokens = llm_daily_usage.output_tokens + EXCLUDED.output_tokens;

--- a/scripts/migrations/023_create_llm_daily_usage_rollback.sql
+++ b/scripts/migrations/023_create_llm_daily_usage_rollback.sql
@@ -1,0 +1,4 @@
+-- 023_create_llm_daily_usage_rollback.sql
+-- Rollback: remove a tabela llm_daily_usage (ledger de consumo de tokens do Bedrock).
+
+DROP TABLE IF EXISTS llm_daily_usage;

--- a/src/data_platform/dags/canonicalize_backfill.py
+++ b/src/data_platform/dags/canonicalize_backfill.py
@@ -1,0 +1,108 @@
+"""DAG: backfill da canonicalizacao de entidades (Step B) via Cloud Run Job.
+
+Dispara o Cloud Run Job `destaquesgovbr-canon-backfill` (imagem + logica no repo
+data-science). O Job percorre `entity_registry_seen` pendente, resolve cada forma
+(gazetteer -> Wikidata -> LLM) e grava `canonical_id`. E resumivel e auto-limitado
+pelo governador de cota (le o ledger `llm_daily_usage`, para gracioso ao atingir
+BACKFILL_QUOTA_FRACTION x cota diaria do modelo).
+
+Schedule diario as 02:00 (defasado do ner_backfill, que roda as 04:00). O governador
+e o teto PRIMARIO; os args `--since`/`--limit` sao apenas guard secundario por execucao.
+
+Espelha o padrao de generate_video_thumbnails (dispara Cloud Run) e sync_graph_to_neo4j
+(import de airflow protegido + config via Variable.get com fallback).
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+try:
+    from airflow.decorators import dag
+    from airflow.models import Variable
+    from airflow.providers.google.cloud.operators.cloud_run import (
+        CloudRunExecuteJobOperator,
+    )
+except ImportError:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Defaults espelham o contrato fixo da infra (Terraform):
+#   - job: google_cloud_run_v2_job.canon_backfill (name destaquesgovbr-canon-backfill)
+#   - region: var.region = southamerica-east1
+# Em prod os valores vem das Airflow Variables (Secret Manager backend, prefixo
+# airflow-variables-): canon_job_name, cloud_run_jobs_region. GCP_PROJECT_ID e env
+# var do Composer (composer.tf).
+DEFAULT_JOB_NAME = "destaquesgovbr-canon-backfill"
+DEFAULT_REGION = "southamerica-east1"
+
+# Janela rolante ampla: cobre o acervo. O governador de cota e o teto real; --since
+# evita reprocessar fora da janela e --limit e um guard secundario por execucao.
+DEFAULT_SINCE = "2018-01-01"
+DEFAULT_RUN_LIMIT = "2000"
+
+
+@dag(
+    dag_id="canonicalize_backfill",
+    description="Backfill da canonicalizacao de entidades (Step B) via Cloud Run Job, sob governador de cota",
+    schedule="0 2 * * *",  # diario as 02:00 (defasado do ner_backfill as 04:00)
+    start_date=datetime(2025, 1, 1),
+    catchup=False,
+    max_active_runs=1,
+    tags=["silver", "entities", "canonicalization", "backfill"],
+    default_args={
+        "owner": "data-platform",
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+        "execution_timeout": timedelta(minutes=70),
+    },
+    doc_md="""
+    ### Backfill da canonicalizacao de entidades (Step B)
+
+    Dispara o Cloud Run Job **destaquesgovbr-canon-backfill** (logica no repo
+    data-science: `canonicalization_job.py`). O Job resolve as formas pendentes em
+    `entity_registry_seen` (gazetteer -> Wikidata -> LLM), grava `canonical_id` em
+    `news_features` e e **resumivel**.
+
+    **Governador de cota (teto primario):** antes de cada batch o Job soma o consumo
+    do dia para o modelo no ledger `llm_daily_usage` e **para gracioso (exit 0)** ao
+    atingir `BACKFILL_QUOTA_FRACTION` (0.8) da cota diaria, deixando >=20% para o
+    worker ao vivo. Retomado na proxima run.
+
+    **Args (guard secundario):** `--since` (janela rolante ampla) e `--limit`
+    (teto por execucao). O grafo (`project_entity_graph`, 6h) cresce sozinho conforme
+    `canonical_id` aumenta.
+
+    Config via Airflow Variables (Secret Manager backend): `canon_job_name`,
+    `cloud_run_jobs_region`, `canon_run_limit`.
+    """,
+)
+def canonicalize_backfill():
+    import os
+
+    project_id = os.environ["GCP_PROJECT_ID"]
+    region = Variable.get("cloud_run_jobs_region", default_var=DEFAULT_REGION)
+    job_name = Variable.get("canon_job_name", default_var=DEFAULT_JOB_NAME)
+    since = Variable.get("canon_backfill_since", default_var=DEFAULT_SINCE)
+    run_limit = Variable.get("canon_run_limit", default_var=DEFAULT_RUN_LIMIT)
+
+    # Formato do overrides conforme RunJobRequest.Overrides (proto-plus, snake_case):
+    # passado direto ao hook -> RunJobRequest(overrides=...). Sobrescreve os args do
+    # unico container do Job; os demais campos (env, imagem) vem do Job no Terraform.
+    CloudRunExecuteJobOperator(
+        task_id="run_canon_backfill",
+        project_id=project_id,
+        region=region,
+        job_name=job_name,
+        overrides={
+            "container_overrides": [
+                {
+                    "args": ["--since", since, "--limit", run_limit],
+                    "clear_args": True,
+                }
+            ],
+        },
+    )
+
+
+dag_instance = canonicalize_backfill()

--- a/src/data_platform/dags/ner_backfill.py
+++ b/src/data_platform/dags/ner_backfill.py
@@ -38,7 +38,7 @@ DEFAULT_REGION = "southamerica-east1"
 # --limit e guard secundario por execucao (governador de cota e o teto real).
 # --order asc processa primeiro o acervo mais antigo (nunca NERado).
 DEFAULT_RUN_LIMIT = "2000"
-DEFAULT_ORDER = "asc"
+DEFAULT_ORDER = "desc"
 
 
 @dag(

--- a/src/data_platform/dags/ner_backfill.py
+++ b/src/data_platform/dags/ner_backfill.py
@@ -1,0 +1,108 @@
+"""DAG: backfill do NER historico (~314k artigos sem NER) via Cloud Run Job.
+
+Dispara o Cloud Run Job `destaquesgovbr-ner-backfill` (imagem + logica no repo
+data-science: `backfill_ner_corpus.py`). O Job seleciona `news` SEM `news_llm_raw`
+task='ner' prompt_version='ner-v1', roda o NER (Sonnet 4.6), grava entidades em
+`news_features` e popula `entity_registry_seen`. E resumivel e auto-limitado pelo
+governador de cota (ledger `llm_daily_usage`, para gracioso ao atingir
+BACKFILL_QUOTA_FRACTION x cota diaria).
+
+Schedule diario as 04:00 (defasado do canonicalize_backfill, que roda as 02:00).
+Ordem `asc` por padrao: processa primeiro o acervo mais antigo (nunca NERado).
+O governador e o teto PRIMARIO; `--limit` e apenas guard secundario por execucao.
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+try:
+    from airflow.decorators import dag
+    from airflow.models import Variable
+    from airflow.providers.google.cloud.operators.cloud_run import (
+        CloudRunExecuteJobOperator,
+    )
+except ImportError:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Defaults espelham o contrato fixo da infra (Terraform):
+#   - job: google_cloud_run_v2_job.ner_backfill (name destaquesgovbr-ner-backfill)
+#   - region: var.region = southamerica-east1
+# Em prod os valores vem das Airflow Variables (Secret Manager backend, prefixo
+# airflow-variables-): ner_job_name, cloud_run_jobs_region. GCP_PROJECT_ID e env
+# var do Composer (composer.tf).
+DEFAULT_JOB_NAME = "destaquesgovbr-ner-backfill"
+DEFAULT_REGION = "southamerica-east1"
+
+# --limit e guard secundario por execucao (governador de cota e o teto real).
+# --order asc processa primeiro o acervo mais antigo (nunca NERado).
+DEFAULT_RUN_LIMIT = "2000"
+DEFAULT_ORDER = "asc"
+
+
+@dag(
+    dag_id="ner_backfill",
+    description="Backfill do NER historico (~314k artigos) via Cloud Run Job, sob governador de cota",
+    schedule="0 4 * * *",  # diario as 04:00 (defasado do canonicalize_backfill as 02:00)
+    start_date=datetime(2025, 1, 1),
+    catchup=False,
+    max_active_runs=1,
+    tags=["silver", "entities", "ner", "backfill"],
+    default_args={
+        "owner": "data-platform",
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+        "execution_timeout": timedelta(minutes=70),
+    },
+    doc_md="""
+    ### Backfill do NER historico (~314k artigos sem NER)
+
+    Dispara o Cloud Run Job **destaquesgovbr-ner-backfill** (logica no repo
+    data-science: `backfill_ner_corpus.py`). O Job seleciona `news` SEM `news_llm_raw`
+    task='ner' prompt_version='ner-v1', roda o NER (Sonnet 4.6), grava entidades em
+    `news_features` e popula `entity_registry_seen` (insumo do canonicalize_backfill).
+    E **resumivel**.
+
+    **Governador de cota (teto primario):** antes de cada batch o Job soma o consumo
+    do dia para o modelo no ledger `llm_daily_usage` e **para gracioso (exit 0)** ao
+    atingir `BACKFILL_QUOTA_FRACTION` (0.8) da cota diaria, deixando >=20% para o
+    worker ao vivo. Como NER e canon usam o mesmo modelo (Sonnet 4.6), ambos medem
+    contra o **mesmo pool** de cota.
+
+    **Args (guard secundario):** `--limit` (teto por execucao) e `--order asc`
+    (acervo mais antigo primeiro).
+
+    Config via Airflow Variables (Secret Manager backend): `ner_job_name`,
+    `cloud_run_jobs_region`, `ner_run_limit`.
+    """,
+)
+def ner_backfill():
+    import os
+
+    project_id = os.environ["GCP_PROJECT_ID"]
+    region = Variable.get("cloud_run_jobs_region", default_var=DEFAULT_REGION)
+    job_name = Variable.get("ner_job_name", default_var=DEFAULT_JOB_NAME)
+    run_limit = Variable.get("ner_run_limit", default_var=DEFAULT_RUN_LIMIT)
+    order = Variable.get("ner_backfill_order", default_var=DEFAULT_ORDER)
+
+    # Formato do overrides conforme RunJobRequest.Overrides (proto-plus, snake_case):
+    # passado direto ao hook -> RunJobRequest(overrides=...). Sobrescreve os args do
+    # unico container do Job; os demais campos (env, imagem) vem do Job no Terraform.
+    CloudRunExecuteJobOperator(
+        task_id="run_ner_backfill",
+        project_id=project_id,
+        region=region,
+        job_name=job_name,
+        overrides={
+            "container_overrides": [
+                {
+                    "args": ["--limit", run_limit, "--order", order],
+                    "clear_args": True,
+                }
+            ],
+        },
+    )
+
+
+dag_instance = ner_backfill()

--- a/tests/unit/dags/test_canonicalize_backfill.py
+++ b/tests/unit/dags/test_canonicalize_backfill.py
@@ -1,0 +1,113 @@
+"""Testes estruturais (AST) da DAG canonicalize_backfill.
+
+Airflow + provider google nao estao instalados localmente e o modulo executa
+dag_instance = canonicalize_backfill() no import (apos try/except ImportError),
+entao usamos testes estruturais via AST (mesmo padrao de test_sync_graph_to_neo4j
+e test_generate_video_thumbnails).
+"""
+
+import ast
+from pathlib import Path
+
+DAG_FILE = Path("src/data_platform/dags/canonicalize_backfill.py")
+
+
+def _parse() -> ast.Module:
+    return ast.parse(DAG_FILE.read_text())
+
+
+def _source() -> str:
+    return DAG_FILE.read_text()
+
+
+def test_parseia_sem_erro():
+    """O modulo deve ser AST-parseavel (gate minimo de sintaxe)."""
+    assert _parse() is not None
+
+
+def test_airflow_protegido_por_try_except():
+    """Imports do airflow/provider so existem no Composer: try/except ImportError no topo."""
+    tree = _parse()
+    has_guard = any(
+        isinstance(node, ast.Try)
+        and any(isinstance(h.type, ast.Name) and h.type.id == "ImportError" for h in node.handlers)
+        for node in tree.body
+    )
+    assert has_guard, "imports do airflow devem estar em try/except ImportError"
+
+
+def test_provider_nao_importado_fora_do_try():
+    """O operador do provider nao pode ser import de topo nao-protegido (quebraria o parse)."""
+    tree = _parse()
+    top_level_imports = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            top_level_imports.append(node.module or "")
+    assert not any("cloud_run" in (m or "") for m in top_level_imports)
+
+
+def test_dag_id_correto():
+    assert 'dag_id="canonicalize_backfill"' in _source()
+
+
+def test_schedule_diario_0200():
+    assert 'schedule="0 2 * * *"' in _source()
+
+
+def test_catchup_false_e_max_active_runs_1():
+    src = _source()
+    assert "catchup=False" in src
+    assert "max_active_runs=1" in src
+
+
+def test_retries_1():
+    assert '"retries": 1' in _source()
+
+
+def test_tags_corretas():
+    src = _source()
+    for tag in ("silver", "entities", "canonicalization", "backfill"):
+        assert f'"{tag}"' in src, f"tag {tag} ausente"
+
+
+def test_usa_cloud_run_execute_job_operator():
+    assert "CloudRunExecuteJobOperator(" in _source()
+
+
+def test_job_name_via_variable_com_default():
+    src = _source()
+    assert 'Variable.get("canon_job_name"' in src
+    assert "destaquesgovbr-canon-backfill" in src
+
+
+def test_region_via_variable_com_default():
+    src = _source()
+    assert 'Variable.get("cloud_run_jobs_region"' in src
+    assert "southamerica-east1" in src
+
+
+def test_project_id_via_env_gcp_project_id():
+    assert 'os.environ["GCP_PROJECT_ID"]' in _source()
+
+
+def test_overrides_usa_container_overrides_snake_case():
+    """Formato do overrides = RunJobRequest.Overrides (proto-plus snake_case)."""
+    src = _source()
+    assert '"container_overrides"' in src
+    assert '"args"' in src
+
+
+def test_args_since_e_limit():
+    src = _source()
+    assert '"--since"' in src
+    assert '"--limit"' in src
+    assert 'Variable.get("canon_run_limit"' in src
+
+
+def test_clear_args_true():
+    """clear_args=True garante substituicao (nao append) dos args default do Job."""
+    assert '"clear_args": True' in _source()
+
+
+def test_instancia_dag_no_modulo():
+    assert "dag_instance = canonicalize_backfill()" in _source()

--- a/tests/unit/dags/test_ner_backfill.py
+++ b/tests/unit/dags/test_ner_backfill.py
@@ -1,0 +1,116 @@
+"""Testes estruturais (AST) da DAG ner_backfill.
+
+Airflow + provider google nao estao instalados localmente e o modulo executa
+dag_instance = ner_backfill() no import (apos try/except ImportError), entao
+usamos testes estruturais via AST (mesmo padrao de test_sync_graph_to_neo4j
+e test_generate_video_thumbnails).
+"""
+
+import ast
+from pathlib import Path
+
+DAG_FILE = Path("src/data_platform/dags/ner_backfill.py")
+
+
+def _parse() -> ast.Module:
+    return ast.parse(DAG_FILE.read_text())
+
+
+def _source() -> str:
+    return DAG_FILE.read_text()
+
+
+def test_parseia_sem_erro():
+    """O modulo deve ser AST-parseavel (gate minimo de sintaxe)."""
+    assert _parse() is not None
+
+
+def test_airflow_protegido_por_try_except():
+    """Imports do airflow/provider so existem no Composer: try/except ImportError no topo."""
+    tree = _parse()
+    has_guard = any(
+        isinstance(node, ast.Try)
+        and any(isinstance(h.type, ast.Name) and h.type.id == "ImportError" for h in node.handlers)
+        for node in tree.body
+    )
+    assert has_guard, "imports do airflow devem estar em try/except ImportError"
+
+
+def test_provider_nao_importado_fora_do_try():
+    """O operador do provider nao pode ser import de topo nao-protegido (quebraria o parse)."""
+    tree = _parse()
+    top_level_imports = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            top_level_imports.append(node.module or "")
+    assert not any("cloud_run" in (m or "") for m in top_level_imports)
+
+
+def test_dag_id_correto():
+    assert 'dag_id="ner_backfill"' in _source()
+
+
+def test_schedule_diario_0400_defasado():
+    """Defasado do canonicalize_backfill (02:00) -> 04:00."""
+    assert 'schedule="0 4 * * *"' in _source()
+
+
+def test_catchup_false_e_max_active_runs_1():
+    src = _source()
+    assert "catchup=False" in src
+    assert "max_active_runs=1" in src
+
+
+def test_retries_1():
+    assert '"retries": 1' in _source()
+
+
+def test_tags_corretas():
+    src = _source()
+    for tag in ("silver", "entities", "ner", "backfill"):
+        assert f'"{tag}"' in src, f"tag {tag} ausente"
+
+
+def test_usa_cloud_run_execute_job_operator():
+    assert "CloudRunExecuteJobOperator(" in _source()
+
+
+def test_job_name_via_variable_com_default():
+    src = _source()
+    assert 'Variable.get("ner_job_name"' in src
+    assert "destaquesgovbr-ner-backfill" in src
+
+
+def test_region_via_variable_com_default():
+    src = _source()
+    assert 'Variable.get("cloud_run_jobs_region"' in src
+    assert "southamerica-east1" in src
+
+
+def test_project_id_via_env_gcp_project_id():
+    assert 'os.environ["GCP_PROJECT_ID"]' in _source()
+
+
+def test_overrides_usa_container_overrides_snake_case():
+    """Formato do overrides = RunJobRequest.Overrides (proto-plus snake_case)."""
+    src = _source()
+    assert '"container_overrides"' in src
+    assert '"args"' in src
+
+
+def test_args_limit_e_order_asc():
+    src = _source()
+    assert '"--limit"' in src
+    assert '"--order"' in src
+    assert 'Variable.get("ner_run_limit"' in src
+    # ordem default 'asc' (acervo mais antigo primeiro)
+    assert '"asc"' in src
+
+
+def test_clear_args_true():
+    """clear_args=True garante substituicao (nao append) dos args default do Job."""
+    assert '"clear_args": True' in _source()
+
+
+def test_instancia_dag_no_modulo():
+    assert "dag_instance = ner_backfill()" in _source()


### PR DESCRIPTION
## Summary

- **Migração 023** (`llm_daily_usage`): ledger account-wide de tokens Bedrock por dia×modelo; base do governador de cota; rollback incluído
- **`canonicalize_backfill.py`**: DAG diária 02:00, dispara Cloud Run Job `destaquesgovbr-canon-backfill` via `CloudRunExecuteJobOperator`; `execution_timeout=70min`
- **`ner_backfill.py`**: DAG diária 04:00, dispara `destaquesgovbr-ner-backfill`; ordem desc (newest-first); `execution_timeout=70min`
- 32 testes unitários estruturais por DAG

## Dependências de deploy (ordem obrigatória)

1. Mergear **infra** PR (cria Jobs + IAM via terraform-apply)
2. Rodar **`db-migrate.yaml`** (migração 023 em prod)
3. Mergear este PR → `composer-deploy-dags.yaml` publica as 2 novas DAGs automaticamente
4. Despausar DAGs no Airflow e monitorar drain

## Test plan

- [ ] CI verde (pytest unit)
- [ ] Após deploy: trigger manual `canonicalize_backfill` → confirmar execução do Job e escrita em `llm_daily_usage`
- [ ] Monitorar `entity_registry_seen.pending↓` e `with_canonical_id↑` nas próximas 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)