### PR TITLE
fix: remover clear_args dos overrides do CloudRunExecuteJobOperator

### DIFF
--- a/src/data_platform/dags/canonicalize_backfill.py
+++ b/src/data_platform/dags/canonicalize_backfill.py
@@ -89,6 +89,7 @@ def canonicalize_backfill():
     # Formato do overrides conforme RunJobRequest.Overrides (proto-plus, snake_case):
     # passado direto ao hook -> RunJobRequest(overrides=...). Sobrescreve os args do
     # unico container do Job; os demais campos (env, imagem) vem do Job no Terraform.
+    # NOTA: clear_args e args sao mutuamente exclusivos na API v2 — usar apenas args.
     CloudRunExecuteJobOperator(
         task_id="run_canon_backfill",
         project_id=project_id,
@@ -98,7 +99,6 @@ def canonicalize_backfill():
             "container_overrides": [
                 {
                     "args": ["--since", since, "--limit", run_limit],
-                    "clear_args": True,
                 }
             ],
         },

--- a/src/data_platform/dags/ner_backfill.py
+++ b/src/data_platform/dags/ner_backfill.py
@@ -89,6 +89,7 @@ def ner_backfill():
     # Formato do overrides conforme RunJobRequest.Overrides (proto-plus, snake_case):
     # passado direto ao hook -> RunJobRequest(overrides=...). Sobrescreve os args do
     # unico container do Job; os demais campos (env, imagem) vem do Job no Terraform.
+    # NOTA: clear_args e args sao mutuamente exclusivos na API v2 — usar apenas args.
     CloudRunExecuteJobOperator(
         task_id="run_ner_backfill",
         project_id=project_id,
@@ -98,7 +99,6 @@ def ner_backfill():
             "container_overrides": [
                 {
                     "args": ["--limit", run_limit, "--order", order],
-                    "clear_args": True,
                 }
             ],
         },


### PR DESCRIPTION
## Problema

Ambos os DAGs de backfill (`canonicalize_backfill`, `ner_backfill`) falhavam com `up_for_retry` após ~17s sem criar nenhuma execução do Cloud Run Job. Exceção real:

```
google.api_core.exceptions.InvalidArgument: 400 Violation in
RunJobRequest.overrides.container_overrides[0].args: Args list for
override must be empty when clear_args field is set to true.
```

## Causa raiz

A API Cloud Run v2 rejeita `RunJobRequest` quando `clear_args=True` e `args=[...]` estão presentes simultaneamente no mesmo `container_override` — são mutuamente exclusivos. O campo `args` já substitui completamente os args do container; `clear_args=True` é apenas para zerar sem substituir.

## Fix

Remove `clear_args: True` dos dois DAGs. O `args` sozinho é suficiente.

## Verificação

- Job `destaquesgovbr-canon-backfill` executado diretamente via `gcloud run jobs execute` com `--args` → sucesso (execução `x9zww` completed)
- IAM confirmado: Composer SA tem `roles/run.invoker` no job