### PR TITLE
feat: DAGs backfill 4×/dia com --workers 10

### DIFF
--- a/src/data_platform/dags/canonicalize_backfill.py
+++ b/src/data_platform/dags/canonicalize_backfill.py
@@ -39,13 +39,14 @@ DEFAULT_REGION = "southamerica-east1"
 # Janela rolante ampla: cobre o acervo. O governador de cota e o teto real; --since
 # evita reprocessar fora da janela e --limit e um guard secundario por execucao.
 DEFAULT_SINCE = "2018-01-01"
-DEFAULT_RUN_LIMIT = "2000"
+DEFAULT_RUN_LIMIT = "5000"
+DEFAULT_WORKERS = "10"
 
 
 @dag(
     dag_id="canonicalize_backfill",
     description="Backfill da canonicalizacao de entidades (Step B) via Cloud Run Job, sob governador de cota",
-    schedule="0 2 * * *",  # diario as 02:00 (defasado do ner_backfill as 04:00)
+    schedule="0 */6 * * *",  # 4x/dia (00:00, 06:00, 12:00, 18:00); governador garante budget; runs extras = retry
     start_date=datetime(2025, 1, 1),
     catchup=False,
     max_active_runs=1,
@@ -54,7 +55,7 @@ DEFAULT_RUN_LIMIT = "2000"
         "owner": "data-platform",
         "retries": 1,
         "retry_delay": timedelta(minutes=5),
-        "execution_timeout": timedelta(minutes=70),
+        "execution_timeout": timedelta(minutes=130),
     },
     doc_md="""
     ### Backfill da canonicalizacao de entidades (Step B)
@@ -85,6 +86,7 @@ def canonicalize_backfill():
     job_name = Variable.get("canon_job_name", default_var=DEFAULT_JOB_NAME)
     since = Variable.get("canon_backfill_since", default_var=DEFAULT_SINCE)
     run_limit = Variable.get("canon_run_limit", default_var=DEFAULT_RUN_LIMIT)
+    workers = Variable.get("canon_workers", default_var=DEFAULT_WORKERS)
 
     # Formato do overrides conforme RunJobRequest.Overrides (proto-plus, snake_case):
     # passado direto ao hook -> RunJobRequest(overrides=...). Sobrescreve os args do
@@ -98,7 +100,7 @@ def canonicalize_backfill():
         overrides={
             "container_overrides": [
                 {
-                    "args": ["--since", since, "--limit", run_limit],
+                    "args": ["--since", since, "--limit", run_limit, "--workers", workers],
                 }
             ],
         },

--- a/src/data_platform/dags/ner_backfill.py
+++ b/src/data_platform/dags/ner_backfill.py
@@ -37,14 +37,15 @@ DEFAULT_REGION = "southamerica-east1"
 
 # --limit e guard secundario por execucao (governador de cota e o teto real).
 # --order asc processa primeiro o acervo mais antigo (nunca NERado).
-DEFAULT_RUN_LIMIT = "2000"
+DEFAULT_RUN_LIMIT = "5000"
 DEFAULT_ORDER = "desc"
+DEFAULT_WORKERS = "10"
 
 
 @dag(
     dag_id="ner_backfill",
     description="Backfill do NER historico (~314k artigos) via Cloud Run Job, sob governador de cota",
-    schedule="0 4 * * *",  # diario as 04:00 (defasado do canonicalize_backfill as 02:00)
+    schedule="0 2-23/6 * * *",  # 4x/dia offset 2h do canon (02:00, 08:00, 14:00, 20:00)
     start_date=datetime(2025, 1, 1),
     catchup=False,
     max_active_runs=1,
@@ -53,7 +54,7 @@ DEFAULT_ORDER = "desc"
         "owner": "data-platform",
         "retries": 1,
         "retry_delay": timedelta(minutes=5),
-        "execution_timeout": timedelta(minutes=70),
+        "execution_timeout": timedelta(minutes=130),
     },
     doc_md="""
     ### Backfill do NER historico (~314k artigos sem NER)
@@ -85,6 +86,7 @@ def ner_backfill():
     job_name = Variable.get("ner_job_name", default_var=DEFAULT_JOB_NAME)
     run_limit = Variable.get("ner_run_limit", default_var=DEFAULT_RUN_LIMIT)
     order = Variable.get("ner_backfill_order", default_var=DEFAULT_ORDER)
+    workers = Variable.get("ner_workers", default_var=DEFAULT_WORKERS)
 
     # Formato do overrides conforme RunJobRequest.Overrides (proto-plus, snake_case):
     # passado direto ao hook -> RunJobRequest(overrides=...). Sobrescreve os args do
@@ -98,7 +100,7 @@ def ner_backfill():
         overrides={
             "container_overrides": [
                 {
-                    "args": ["--limit", run_limit, "--order", order],
+                    "args": ["--limit", run_limit, "--order", order, "--workers", workers],
                 }
             ],
         },


### PR DESCRIPTION
## Summary

- **4×/dia** para ambos os DAGs: o governador garante que só a primeira run do dia consome o budget real; as demais saem em <5s (budget_exhausted=True imediato) — mas se a primeira falha, há 3 chances de retry automático no mesmo dia
- **canon**: `0 2 * * *` → `0 */6 * * *` (00:00, 06:00, 12:00, 18:00 UTC)  
- **NER**: `0 4 * * *` → `0 2-23/6 * * *` (02:00, 08:00, 14:00, 20:00 UTC — offset 2h do canon para garantir que canon roda primeiro e consome sua fatia antes do NER)
- **`--workers 10`** via Airflow Variable `canon_workers`/`ner_workers` (default `"10"`)
- `DEFAULT_RUN_LIMIT` 2000→5000 (governador é o teto real; limite é só guard secundário)
- `execution_timeout` 70→130min (alinhado ao timeout do Cloud Run Job de 7200s)

## Test plan

- [ ] CI verde (DAGs parseiam sem erro)
- [ ] Trigger manual: canon processa ~2k formas em ~36min com 10 workers
- [ ] NER trigger 2h depois: usa o saldo do budget (~350 artigos)
- [ ] Segunda trigger do dia: sai imediatamente com `budget_exhausted=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)