### PR TITLE
fix(graph): sync_graph_to_neo4j remove nós stale (cleanup pós-merge)

### DIFF
--- a/src/data_platform/jobs/graph/neo4j_sync.py
+++ b/src/data_platform/jobs/graph/neo4j_sync.py
@@ -113,6 +113,19 @@ _MERGE_EDGES_CYPHER_TMPL = """
         r.last_seen = row.last_seen
 """
 
+# Cleanup de nos obsoletos: o MERGE acima nunca remove nos que sairam do Postgres
+# (ex.: o source de um merge/dedup, ou a promocao Wikidata-wins do add_alias que
+# funde dgb_->QID continuamente no canon job). Sem este passo, o Neo4j acumula
+# nos stale com arestas mortas. Remove todo :Entity cujo entity_id nao esta no
+# conjunto corrente do Postgres. `count(*)` apos DETACH DELETE conta as linhas
+# processadas (idioma valido no Cypher).
+DELETE_STALE_NODES_CYPHER = """
+    MATCH (e:Entity)
+    WHERE NOT e.entity_id IN $valid_ids
+    DETACH DELETE e
+    RETURN count(*) AS deleted
+"""
+
 
 def _chunked(items: list, size: int):
     """Divide uma lista em lotes de tamanho `size`."""
@@ -192,6 +205,21 @@ def sync_graph_to_neo4j(db_url: str, bolt_config: dict) -> dict:
                     session.run(cypher, rows=batch)
                     count += len(batch)
                 result["edges"][rel_type] = count
+
+            # Cleanup de nos stale (nao existem mais no Postgres). GUARD: so limpa
+            # se houve nos sincronizados — um fetch_nodes vazio (erro/transitorio)
+            # NUNCA deve zerar o grafo.
+            if nodes:
+                valid_ids = [n["entity_id"] for n in nodes]
+                rec = session.run(
+                    DELETE_STALE_NODES_CYPHER, valid_ids=valid_ids
+                ).single()
+                result["deleted_stale"] = rec["deleted"] if rec else 0
+            else:
+                logger.warning(
+                    "fetch_nodes vazio — pulando cleanup de nos stale (protecao)"
+                )
+                result["deleted_stale"] = 0
     finally:
         driver.close()
 

--- a/tests/unit/jobs/graph/test_neo4j_sync.py
+++ b/tests/unit/jobs/graph/test_neo4j_sync.py
@@ -14,6 +14,7 @@ import pytest
 from data_platform.jobs.graph.neo4j_sync import (
     _MERGE_EDGES_CYPHER_TMPL,
     BATCH_SIZE,
+    DELETE_STALE_NODES_CYPHER,
     EDGE_KIND_TO_REL,
     MERGE_NODES_CYPHER,
     _chunked,
@@ -69,6 +70,13 @@ class TestCypherInvariants:
     def test_template_de_aresta_injeta_o_rel_type(self):
         cypher = _MERGE_EDGES_CYPHER_TMPL.format(rel_type="SUBORDINATE_TO")
         assert "[r:SUBORDINATE_TO]" in cypher
+
+    def test_cleanup_remove_nos_fora_do_conjunto_valido(self):
+        """O cleanup deleta :Entity cujo entity_id NAO esta no conjunto corrente."""
+        norm = _normalize(DELETE_STALE_NODES_CYPHER)
+        assert "match (e:entity)" in norm
+        assert "where not e.entity_id in $valid_ids" in norm
+        assert "detach delete e" in norm
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +202,58 @@ class TestSyncOrchestration:
         assert constraint_calls, "deve criar CONSTRAINT entity_id IS UNIQUE"
 
         driver.close.assert_called_once()
+
+    def test_cleanup_deleta_nos_stale_com_valid_ids(self):
+        """Após o MERGE, roda o DELETE de nós stale com os entity_ids correntes."""
+        from data_platform.jobs.graph import neo4j_sync
+
+        session = MagicMock()
+        session.run.return_value.single.return_value = {"deleted": 4}
+        driver = MagicMock()
+        driver.session.return_value.__enter__.return_value = session
+
+        nodes = [
+            {"entity_id": "Q1", "name": "A", "type": "ORG", "wikidata_id": "Q1", "agency_key": None},
+            {"entity_id": "Q2", "name": "B", "type": "PER", "wikidata_id": None, "agency_key": None},
+        ]
+
+        patcher, _ = self._install_fake_neo4j(driver)
+        with patcher, patch.object(neo4j_sync, "fetch_nodes", return_value=nodes), patch.object(
+            neo4j_sync, "fetch_edges", return_value=[]
+        ):
+            result = neo4j_sync.sync_graph_to_neo4j(
+                "postgresql://x", {"url": "bolt://x:7687", "password": "p"}
+            )
+
+        # achou a chamada de DELETE com valid_ids = ids dos nós sincronizados
+        delete_calls = [
+            c for c in session.run.call_args_list if "DETACH DELETE" in str(c.args[0])
+        ]
+        assert len(delete_calls) == 1
+        assert delete_calls[0].kwargs["valid_ids"] == ["Q1", "Q2"]
+        assert result["deleted_stale"] == 4
+
+    def test_cleanup_pulado_quando_fetch_nodes_vazio(self):
+        """GUARD: fetch_nodes vazio NUNCA dispara o DELETE (não zera o grafo)."""
+        from data_platform.jobs.graph import neo4j_sync
+
+        session = MagicMock()
+        driver = MagicMock()
+        driver.session.return_value.__enter__.return_value = session
+
+        patcher, _ = self._install_fake_neo4j(driver)
+        with patcher, patch.object(neo4j_sync, "fetch_nodes", return_value=[]), patch.object(
+            neo4j_sync, "fetch_edges", return_value=[]
+        ):
+            result = neo4j_sync.sync_graph_to_neo4j(
+                "postgresql://x", {"url": "bolt://x", "password": "p"}
+            )
+
+        delete_calls = [
+            c for c in session.run.call_args_list if "DETACH DELETE" in str(c.args[0])
+        ]
+        assert delete_calls == []
+        assert result["deleted_stale"] == 0
 
     def test_driver_fechado_mesmo_com_erro(self):
         from data_platform.jobs.graph import neo4j_sync


### PR DESCRIPTION
## Problema

`sync_graph_to_neo4j` era **MERGE-only**: fazia upsert dos nós/arestas correntes do Postgres, mas **nunca removia** do Neo4j os nós `:Entity` que saíram do Postgres. Como entidades são fundidas **continuamente** — o `add_alias` Wikidata-wins promove `dgb_`→QID a cada canonicalização no canon job, além dos `--dedup` retroativos — o Neo4j acumulava **nós stale com arestas mortas**.

Detectado durante a retroatividade do dedup ORG (data-science): após 36 merges, o Neo4j ficou com 36 nós órfãos (1143 vs 1107 no Postgres), exigindo cleanup manual via túnel SSH. Sem este fix, o cleanup manual precisaria repetir periodicamente.

## Mudança

Passo de cleanup ao final do `sync_graph_to_neo4j`, na mesma sessão:
```cypher
MATCH (e:Entity) WHERE NOT e.entity_id IN $valid_ids DETACH DELETE e RETURN count(*) AS deleted
```
onde `valid_ids` = entity_ids dos nós recém-sincronizados (conjunto corrente do Postgres).

**Guard de segurança:** só executa se `fetch_nodes` retornou nós. Um fetch vazio (erro transitório) **nunca** zera o grafo. Retorna `deleted_stale` no resultado para observabilidade.

## Testes
- Invariante do Cypher de cleanup (MATCH + WHERE NOT IN + DETACH DELETE).
- Deleção dispara com `valid_ids` = ids sincronizados; `deleted_stale` propagado.
- **Guard**: `fetch_nodes` vazio → nenhum DELETE é executado.
- 20 testes no módulo `neo4j_sync`, 43 no conjunto graph + sync DAG, 0 falhas.

Após merge: `composer-deploy-dags` publica; o próximo `sync_graph_to_neo4j` (a cada 6h) passa a autolimpar — sem mais cleanup manual.