### PR TITLE
fix: inclui trend_detection no deploy de plugins do Composer

### DIFF
--- a/.github/workflows/composer-deploy-dags.yaml
+++ b/.github/workflows/composer-deploy-dags.yaml
@@ -63,6 +63,7 @@ jobs:
           cp -r src/data_platform/jobs/integrity /tmp/plugins/data_platform/jobs/
           cp -r src/data_platform/jobs/similarity /tmp/plugins/data_platform/jobs/
           cp -r src/data_platform/jobs/thumbnail /tmp/plugins/data_platform/jobs/
+          cp -r src/data_platform/jobs/trend_detection /tmp/plugins/data_platform/jobs/
           # Deploy only typesense modules needed by DAGs (skip indexer.py — depends on pandas)
           cp src/data_platform/typesense/client.py /tmp/plugins/data_platform/typesense/
           cp src/data_platform/typesense/collection.py /tmp/plugins/data_platform/typesense/


### PR DESCRIPTION
## Summary

- O step `deploy-plugins` no workflow `composer-deploy-dags.yaml` listava submódulos explicitamente e estava faltando `trend_detection`
- Isso causava `ModuleNotFoundError: No module named 'data_platform.jobs.trend_detection'` no DAG `compute_entity_trending`
- Adiciona `cp -r src/data_platform/jobs/trend_detection` à lista de módulos deployados

## Deploy manual

O módulo já foi copiado manualmente para `gs://southamerica-east1-destaque-227e22da-bucket/plugins/data_platform/jobs/trend_detection/` para desbloquear o DAG imediatamente.