### PR TITLE
feature: adiciona campo fallback_triggered à tabela scrape_runs

### DIFF
--- a/scripts/migrations/026_add_fallback_triggered.sql
+++ b/scripts/migrations/026_add_fallback_triggered.sql
@@ -1,0 +1,15 @@
+-- 026_add_fallback_triggered.sql
+-- Adiciona campo para rastrear quando fallback do scraper foi acionado.
+-- Ref: destaquesgovbr/scraper#60
+
+ALTER TABLE scrape_runs
+    ADD COLUMN IF NOT EXISTS fallback_triggered BOOLEAN DEFAULT FALSE;
+
+-- Partial index: apenas registros com fallback (otimiza queries)
+CREATE INDEX IF NOT EXISTS idx_scrape_runs_fallback
+    ON scrape_runs (fallback_triggered, scraped_at DESC)
+    WHERE fallback_triggered = true;
+
+-- Comentário na coluna para documentação
+COMMENT ON COLUMN scrape_runs.fallback_triggered IS
+    'Indica se o fallback automático (WebScraper → Plone6APIScraper) foi acionado devido a erro HTML_CHANGED';

--- a/scripts/migrations/026_add_fallback_triggered_rollback.sql
+++ b/scripts/migrations/026_add_fallback_triggered_rollback.sql
@@ -1,0 +1,4 @@
+-- Rollback for 026_add_fallback_triggered.sql
+
+DROP INDEX IF EXISTS idx_scrape_runs_fallback;
+ALTER TABLE scrape_runs DROP COLUMN IF EXISTS fallback_triggered;

--- a/tests/unit/dags/test_canonicalize_backfill.py
+++ b/tests/unit/dags/test_canonicalize_backfill.py
@@ -50,8 +50,10 @@ def test_dag_id_correto():
     assert 'dag_id="canonicalize_backfill"' in _source()
 
 
-def test_schedule_diario_0200():
-    assert 'schedule="0 2 * * *"' in _source()
+def test_schedule_4x_dia():
+    # PR #185: Schedule mudou de diário (0 2 * * *) para 4x/dia (0 */6 * * *)
+    # Runs extras funcionam como retry resiliente; governador de cota garante budget
+    assert 'schedule="0 */6 * * *"' in _source()
 
 
 def test_catchup_false_e_max_active_runs_1():
@@ -104,9 +106,20 @@ def test_args_since_e_limit():
     assert 'Variable.get("canon_run_limit"' in src
 
 
-def test_clear_args_true():
-    """clear_args=True garante substituicao (nao append) dos args default do Job."""
-    assert '"clear_args": True' in _source()
+def test_args_passed_via_overrides():
+    """Args passados via overrides.container_overrides (clear_args foi removido).
+
+    PR #185 (commit b5f5a56): clear_args e args são mutuamente exclusivos na API
+    Cloud Run v2. Apenas args já substitui os args do container.
+    """
+    src = _source()
+    # Verifica que args são passados via container_overrides
+    assert '"args":' in src
+    assert '--since' in src
+    assert '--limit' in src
+    assert '--workers' in src
+    # clear_args foi removido do código (apenas aparece em comentário agora)
+    assert '"clear_args"' not in src  # Não aparece como chave no dicionário
 
 
 def test_instancia_dag_no_modulo():

--- a/tests/unit/dags/test_ner_backfill.py
+++ b/tests/unit/dags/test_ner_backfill.py
@@ -50,9 +50,14 @@ def test_dag_id_correto():
     assert 'dag_id="ner_backfill"' in _source()
 
 
-def test_schedule_diario_0400_defasado():
-    """Defasado do canonicalize_backfill (02:00) -> 04:00."""
-    assert 'schedule="0 4 * * *"' in _source()
+def test_schedule_4x_dia_offset_2h():
+    """Schedule 4x/dia com offset de 2h do canonicalize_backfill.
+
+    PR #185: Schedule mudou de diário (0 4 * * *) para 4x/dia (0 2-23/6 * * *)
+    Offset de 2h garante que NER roda após canon: 02:00, 08:00, 14:00, 20:00
+    Canon roda em: 00:00, 06:00, 12:00, 18:00
+    """
+    assert 'schedule="0 2-23/6 * * *"' in _source()
 
 
 def test_catchup_false_e_max_active_runs_1():
@@ -98,18 +103,33 @@ def test_overrides_usa_container_overrides_snake_case():
     assert '"args"' in src
 
 
-def test_args_limit_e_order_asc():
+def test_args_limit_e_order_desc():
+    """Valida que args --limit e --order são passados corretamente.
+
+    Commit df5d809: Ordem mudou de 'asc' para 'desc' (newest-first por padrão).
+    """
     src = _source()
     assert '"--limit"' in src
     assert '"--order"' in src
     assert 'Variable.get("ner_run_limit"' in src
-    # ordem default 'asc' (acervo mais antigo primeiro)
-    assert '"asc"' in src
+    # Ordem default 'desc' (artigos mais novos primeiro)
+    assert 'DEFAULT_ORDER = "desc"' in src
 
 
-def test_clear_args_true():
-    """clear_args=True garante substituicao (nao append) dos args default do Job."""
-    assert '"clear_args": True' in _source()
+def test_args_passed_via_overrides():
+    """Args passados via overrides.container_overrides (clear_args foi removido).
+
+    Commit b5f5a56: clear_args e args são mutuamente exclusivos na API Cloud Run v2.
+    Apenas args já substitui os args do container.
+    """
+    src = _source()
+    # Verifica que args são passados via container_overrides
+    assert '"args":' in src
+    assert '--limit' in src
+    assert '--order' in src
+    assert '--workers' in src
+    # clear_args foi removido do código (apenas aparece em comentário agora)
+    assert '"clear_args"' not in src  # Não aparece como chave no dicionário
 
 
 def test_instancia_dag_no_modulo():


### PR DESCRIPTION
## Descrição

Adiciona rastreamento de quando o fallback automático do scraper foi acionado (WebScraper → Plone6APIScraper).

## Mudanças

**Migration 026:**
- Adiciona coluna `fallback_triggered` (BOOLEAN, default FALSE)
- Cria índice parcial otimizado para queries de fallback (`WHERE fallback_triggered = true`)
- Adiciona comentário na coluna para documentação

**Rollback 026:**
- Remove índice e coluna

## Contexto

Relacionado ao PR destaquesgovbr/scraper#60 que implementa fallback automático entre scrapers quando a estrutura HTML de sites gov.br muda.

## Como testar

Após aplicar a migration em dev/staging:

```sql
-- Verificar que coluna foi criada
\d scrape_runs

-- Verificar índice
\di idx_scrape_runs_fallback

-- Query de teste
SELECT agency_key, COUNT(*) as fallback_count
FROM scrape_runs
WHERE fallback_triggered = true
GROUP BY agency_key;
```

## Deploy

- [ ] Aplicar migration em staging
- [ ] Validar schema
- [ ] Aplicar migration em produção
- [ ] Merge PR scraper#60 (aguarda esta migration)

Ref: destaquesgovbr/scraper#60